### PR TITLE
[BE] 애플 로그인 revoke 요청이 실패하는 오류 수정

### DIFF
--- a/src/main/java/site/dogether/auth/infrastructure/AppleClientSecret.java
+++ b/src/main/java/site/dogether/auth/infrastructure/AppleClientSecret.java
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class AppleClientSecretGenerator {
+public class AppleClientSecret {
 
     private final JwtHandler jwtHandler;
 
@@ -30,7 +30,7 @@ public class AppleClientSecretGenerator {
     @Value("${secret.oauth.apple.private-key}")
     private String privateKey;
 
-    public String createClientSecret() {
+    public String generate() {
         final Date expireDate = Date.from(
                 LocalDateTime.now()
                         .plusMinutes(5)

--- a/src/main/java/site/dogether/auth/infrastructure/AppleOAuthProvider.java
+++ b/src/main/java/site/dogether/auth/infrastructure/AppleOAuthProvider.java
@@ -23,7 +23,7 @@ import site.dogether.auth.infrastructure.client.apple.response.ApplePublicKeySet
 public class AppleOAuthProvider {
 
     private final AppleApiClient appleApiClient;
-    private final AppleClientSecretGenerator appleClientSecretGenerator;
+    private final AppleClientSecret appleClientSecret;
     private final JwtHandler jwtHandler;
     private final ObjectMapper objectMapper;
 
@@ -40,14 +40,14 @@ public class AppleOAuthProvider {
         return null;
     }
 
-    public void revoke(String authorizationCode) {
-        final String clientSecret = appleClientSecretGenerator.createClientSecret();
+    public boolean revoke(String authorizationCode) {
+        final String clientSecret = appleClientSecret.generate();
         log.info("Apple client secret을 생성합니다. clientSecret: {}", clientSecret);
 
         final String refreshToken = appleApiClient.requestRefreshToken(clientSecret, authorizationCode);
         log.info("Apple refresh token을 요청합니다. refreshToken: {}", refreshToken);
 
-        appleApiClient.requestRevoke(clientSecret, refreshToken);
+        return appleApiClient.requestRevoke(clientSecret, refreshToken);
     }
 
     private PublicKey getApplePublicKey(final Map<String, String> header)

--- a/src/main/java/site/dogether/auth/infrastructure/JwtHandler.java
+++ b/src/main/java/site/dogether/auth/infrastructure/JwtHandler.java
@@ -62,18 +62,29 @@ public class JwtHandler {
         return token;
     }
 
-    public String createClientSecret(final String keyId, final String teamId, final Date expireDate,
-                                     final String audience, final String clientId, final PrivateKey privateKey) {
-        return Jwts.builder()
-                .header()
-                    .add("alg", Jwts.SIG.ES256).add("kid", keyId).and()
-                .issuer(teamId)
-                .issuedAt(new Date(System.currentTimeMillis()))
-                .expiration(expireDate)
-                .audience().add(audience).and()
-                .subject(clientId)
-                .signWith(privateKey, Jwts.SIG.ES256)
-                .compact();
+    public String createClientSecret(final String keyId,
+                                     final String teamId,
+                                     final Date expireDate,
+                                     final String audience,
+                                     final String clientId,
+                                     final PrivateKey privateKey) {
+        try {
+            return Jwts.builder()
+                    .header()
+                    .add("alg", "ES256")
+                    .add("kid", keyId)
+                    .and()
+                    .issuer(teamId)
+                    .issuedAt(new Date())
+                    .expiration(expireDate)
+                    .audience().add(audience).and()
+                    .subject(clientId)
+                    .signWith(privateKey, Jwts.SIG.ES256)
+                    .compact();
+        } catch (Exception e) {
+            log.warn("Apple Client Secret 생성에 실패하였습니다.");
+            throw new RuntimeException();
+        }
     }
 
     public Long getMemberId(final String bearerToken) {

--- a/src/main/java/site/dogether/auth/infrastructure/client/apple/AppleApiClient.java
+++ b/src/main/java/site/dogether/auth/infrastructure/client/apple/AppleApiClient.java
@@ -42,19 +42,26 @@ public class AppleApiClient {
         return response.refreshToken();
     }
 
-    public void requestRevoke(final String clientSecret, final String refreshToken) {
-        RestClient.create()
-                .post()
-                .uri("https://appleid.apple.com/auth/revoke")
-                .body("client_id=" + clientId
-                        + "&client_secret=" + clientSecret
-                        + "&token=" + refreshToken
-                        + "&token_type_hint=" + "refresh_token")
-                .retrieve()
-                .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
-                    log.warn("Apple Revoke 요청에 실패하였습니다.");
-                    throw new RuntimeException("Apple Revoke 요청에 실패하였습니다.");
-                });
-        log.info("Apple Revoke 요청에 성공하였습니다.");
+    public boolean requestRevoke(final String clientSecret, final String refreshToken) {
+        try {
+            RestClient.create()
+                    .post()
+                    .uri("https://appleid.apple.com/auth/revoke")
+                    .body("client_id=" + clientId
+                            + "&client_secret=" + clientSecret
+                            + "&token=" + refreshToken
+                            + "&token_type_hint=refresh_token")
+                    .retrieve()
+                    .onStatus(HttpStatusCode::is4xxClientError, (req, res) -> {
+                        log.warn("Apple Revoke 요청에 실패하였습니다.");
+                        throw new RuntimeException("Apple Revoke 요청에 실패하였습니다.");
+                    });
+            log.info("Apple Revoke 요청에 성공하였습니다.");
+            return true;
+        } catch (Exception e) {
+            log.warn("Apple Revoke 중 예외 발생: {}", e.getMessage());
+            return false;
+        }
     }
+
 }

--- a/src/main/java/site/dogether/auth/service/AuthService.java
+++ b/src/main/java/site/dogether/auth/service/AuthService.java
@@ -38,7 +38,9 @@ public class AuthService {
 
     @Transactional
     public void withdraw(final Long memberId, final WithdrawRequest request) {
-        appleOAuthProvider.revoke(request.authorizationCode());
-        memberService.delete(memberId);
+        boolean isRevoked = appleOAuthProvider.revoke(request.authorizationCode());
+        if (isRevoked) {
+            memberService.delete(memberId);
+        }
     }
 }


### PR DESCRIPTION
- Apple Client Secret 생성 시 `Jwts.builder().header`에 들어갈 alg를 String으로 변경
- 가독성을 위한 개행, 네이밍 개선
- 예외 처리 필요한 부분 추가
- revoke의 성공 여부에 따라 회원 정보를 삭제하도록 개선
