### PR TITLE
[BE] RT 요청 시 ErrorResponse 매핑, 로깅 추가

### DIFF
--- a/src/main/java/site/dogether/auth/controller/AuthController.java
+++ b/src/main/java/site/dogether/auth/controller/AuthController.java
@@ -28,9 +28,8 @@ public class AuthController {
             @RequestBody final LoginRequest request
     ) {
         final AuthenticatedMember authenticatedMember = authService.login(request);
-        final LoginResponse response = new LoginResponse(authenticatedMember);
         return ResponseEntity.ok(ApiResponse.successWithData(
-            LOGIN, response
+            LOGIN, new LoginResponse(authenticatedMember)
         ));
     }
 

--- a/src/main/java/site/dogether/auth/infrastructure/AppleOAuthProvider.java
+++ b/src/main/java/site/dogether/auth/infrastructure/AppleOAuthProvider.java
@@ -27,7 +27,7 @@ public class AppleOAuthProvider {
     private final JwtHandler jwtHandler;
     private final ObjectMapper objectMapper;
 
-    public String getSubjectFromIdToken(final String idToken) {
+    public String parseSubject(final String idToken) {
         final String headerOfIdToken = idToken.split("\\.")[0];
         final String decodedHeader = new String(Base64.getDecoder().decode(headerOfIdToken));
         try {

--- a/src/main/java/site/dogether/auth/infrastructure/JwtHandler.java
+++ b/src/main/java/site/dogether/auth/infrastructure/JwtHandler.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtHandler {
 
-    public static final String PREFIX = "Bearer ";
+    private static final String PREFIX = "Bearer ";
 
     @Value("${secret.jwt.secret-key}")
     private String secret;

--- a/src/main/java/site/dogether/auth/service/AuthService.java
+++ b/src/main/java/site/dogether/auth/service/AuthService.java
@@ -24,7 +24,7 @@ public class AuthService {
 
     @Transactional
     public AuthenticatedMember login(final LoginRequest request) {
-        final String subject = appleOAuthProvider.getSubjectFromIdToken(request.idToken());
+        final String subject = appleOAuthProvider.parseSubject(request.idToken());
         log.info("subject of apple idToken 을 파싱합니다. sub: {}", subject);
 
         Member member = new Member(subject, request.name());


### PR DESCRIPTION
애플 refresh token 요청 시 발생하는 오류 수정을 위해 ErrorResponse를 매핑, 로깅을 추가합니다.

https://developer.apple.com/documentation/signinwithapplerestapi/errorresponse