### PR TITLE
[BE] 챌린지 그룹 테이블에 잘못된 컬럼 타입 수정 & updated_at 컬럼 잘못된 기본값 삽입 수정

### DIFF
--- a/src/main/java/site/dogether/DogetherApplication.java
+++ b/src/main/java/site/dogether/DogetherApplication.java
@@ -2,10 +2,8 @@ package site.dogether;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class DogetherApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -9,7 +9,6 @@ import site.dogether.challengegroup.exception.InvalidChallengeGroupException;
 import site.dogether.common.audit.entity.BaseEntity;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @ToString
@@ -34,10 +33,10 @@ public class ChallengeGroup extends BaseEntity {
     private int maximumMemberCount;
 
     @Column(name = "start_at", nullable = false)
-    private LocalDateTime startAt;
+    private LocalDate startAt;
 
     @Column(name = "end_at", nullable = false)
-    private LocalDateTime endAt;
+    private LocalDate endAt;
 
     @Column(name = "join_code", length = 20, nullable = false, unique = true)
     private String joinCode;
@@ -49,8 +48,8 @@ public class ChallengeGroup extends BaseEntity {
     public static ChallengeGroup create(
         final String name,
         final int maximumMemberCount,
-        final LocalDateTime startAt,
-        final LocalDateTime endAt
+        final LocalDate startAt,
+        final LocalDate endAt
     ) {
         return new ChallengeGroup(
             null,
@@ -67,8 +66,8 @@ public class ChallengeGroup extends BaseEntity {
         return UUID.randomUUID().toString().substring(0, 6);
     }
 
-    private static ChallengeGroupStatus determineStatus(final LocalDateTime startAt) {
-        if (startAt.toLocalDate().equals(LocalDate.now())) {
+    private static ChallengeGroupStatus determineStatus(final LocalDate startAt) {
+        if (startAt.equals(LocalDate.now())) {
             return ChallengeGroupStatus.RUNNING;
         }
 
@@ -79,8 +78,8 @@ public class ChallengeGroup extends BaseEntity {
         final Long id,
         final String name,
         final int maximumMemberCount,
-        final LocalDateTime startAt,
-        final LocalDateTime endAt,
+        final LocalDate startAt,
+        final LocalDate endAt,
         final String joinCode,
         final ChallengeGroupStatus status
     ) {

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupDurationOption.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupDurationOption.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import site.dogether.challengegroup.exception.InvalidChallengeGroupException;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -19,12 +19,7 @@ public enum ChallengeGroupDurationOption {
     ;
 
     private final int value;
-    private final Function<LocalDateTime, LocalDateTime> endAtCalculator;
-
-    public static ChallengeGroupDurationOption from(final LocalDateTime startAt, final LocalDateTime endAt) {
-        final int duration = endAt.getDayOfYear() - startAt.getDayOfYear();
-        return from(duration);
-    }
+    private final Function<LocalDate, LocalDate> endAtCalculator;
 
     public static ChallengeGroupDurationOption from(final int durationOption) {
         return Arrays.stream(ChallengeGroupDurationOption.values())
@@ -33,7 +28,7 @@ public enum ChallengeGroupDurationOption {
             .orElseThrow(() -> new InvalidChallengeGroupException("유효하지 않은 기간 옵션입니다. " + durationOption + "일"));
     }
 
-    public LocalDateTime calculateEndAt(final LocalDateTime startAt) {
+    public LocalDate calculateEndAt(final LocalDate startAt) {
         return endAtCalculator.apply(startAt);
     }
 }

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupStartAtOption.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupStartAtOption.java
@@ -3,17 +3,17 @@ package site.dogether.challengegroup.entity;
 import lombok.RequiredArgsConstructor;
 import site.dogether.challengegroup.exception.InvalidChallengeGroupException;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.function.Supplier;
 
 @RequiredArgsConstructor
 public enum ChallengeGroupStartAtOption {
 
-    TODAY(LocalDateTime::now),
-    TOMORROW(() -> LocalDateTime.now().plusDays(1)),
+    TODAY(LocalDate::now),
+    TOMORROW(() -> LocalDate.now().plusDays(1)),
     ;
 
-    private final Supplier<LocalDateTime> startAtCalculator;
+    private final Supplier<LocalDate> startAtCalculator;
 
     public static ChallengeGroupStartAtOption from(final String startAt) {
         validateStartAt(startAt);
@@ -30,7 +30,7 @@ public enum ChallengeGroupStartAtOption {
         }
     }
 
-    public LocalDateTime calculateStartAt() {
+    public LocalDate calculateStartAt() {
         return startAtCalculator.get();
     }
 }

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -23,6 +23,7 @@ import site.dogether.member.entity.Member;
 import site.dogether.member.service.MemberService;
 import site.dogether.notification.service.NotificationService;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
@@ -45,8 +46,8 @@ public class ChallengeGroupService {
         final Member member = memberService.getMember(memberId);
         memberAlreadyInGroup(member);
 
-        final LocalDateTime startAt = request.challengeGroupStartAtOption().calculateStartAt();
-        final LocalDateTime endAt = request.challengeGroupDurationOption().calculateEndAt(startAt);
+        final LocalDate startAt = request.challengeGroupStartAtOption().calculateStartAt();
+        final LocalDate endAt = request.challengeGroupDurationOption().calculateEndAt(startAt);
         final ChallengeGroup challengeGroup = ChallengeGroup.create(
             request.name(),
             request.maximumMemberCount(),
@@ -121,7 +122,7 @@ public class ChallengeGroupService {
         isGroupFinished(challengeGroup);
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd"); // TODO : 도메인으로 이동
-        LocalDateTime endAt = challengeGroup.getEndAt();
+        LocalDate endAt = challengeGroup.getEndAt();
         String endAtFormatted = endAt.format(formatter);
 
         long remainingDays = LocalDateTime.now().until(endAt, ChronoUnit.DAYS);

--- a/src/main/java/site/dogether/common/audit/entity/BaseEntity.java
+++ b/src/main/java/site/dogether/common/audit/entity/BaseEntity.java
@@ -1,31 +1,31 @@
 package site.dogether.common.audit.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.*;
 import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
-@EntityListeners(value = {AuditingEntityListener.class})
 public class BaseEntity {
 
-    @CreatedDate
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    @Column(columnDefinition = "TIMESTAMP", nullable = false, updatable = false)
+    @Column(nullable = false, updatable = false)
     protected LocalDateTime createdAt;
 
-    @LastModifiedDate
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    @Column(columnDefinition = "TIMESTAMP")
+    @Column
     protected LocalDateTime updatedAt;
 
     @Column(columnDefinition = "TINYINT(1) DEFAULT 0", nullable = false)
     protected boolean isDeleted = false;
+
+    @PrePersist
+    public void prePersist() {
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = null;
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
 }

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -9,8 +9,8 @@ import site.dogether.challengegroup.entity.ChallengeGroupStatus;
 import site.dogether.dailytodo.controller.DailyTodoController;
 import site.dogether.dailytodo.controller.request.CertifyDailyTodoRequest;
 import site.dogether.dailytodo.controller.request.CreateDailyTodosRequest;
-import site.dogether.dailytodo.entity.DailyTodoStatus;
 import site.dogether.dailytodo.entity.DailyTodo;
+import site.dogether.dailytodo.entity.DailyTodoStatus;
 import site.dogether.dailytodo.service.DailyTodoService;
 import site.dogether.dailytodo.service.dto.DailyTodoAndDailyTodoCertificationDto;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
@@ -18,7 +18,6 @@ import site.dogether.docs.util.RestDocsSupport;
 import site.dogether.member.entity.Member;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -153,7 +152,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
     void getMyDailyTodos() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly");
         final Member reviewer = new Member(2L, "elmo-id", "elmo");
-        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDateTime.now(), LocalDateTime.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
+        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
         final List<DailyTodo> dailyTodos = List.of(
             new DailyTodo(1L, challengeGroup, doer, "치킨 먹기", DailyTodoStatus.CERTIFY_PENDING, null),
             new DailyTodo(2L, challengeGroup, doer, "운동 하기", DailyTodoStatus.REVIEW_PENDING, null),
@@ -222,7 +221,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
     void getMyDailyTodosWithDailyTodoStatus() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly");
         final Member reviewer = new Member(2L, "elmo-id", "elmo");
-        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDateTime.now(), LocalDateTime.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
+        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
         final DailyTodo dailyTodo = new DailyTodo(2L, challengeGroup, doer,  "운동 하기", DailyTodoStatus.REVIEW_PENDING, null);
         final DailyTodoCertification dailyTodoCertification = new DailyTodoCertification(1L, dailyTodo, reviewer, "운동 개조짐 ㅋㅋㅋㅋ", "https://image.url");
         final List<DailyTodoAndDailyTodoCertificationDto> dailyTodoAndDailyTodoCertificationDtos = List.of(new DailyTodoAndDailyTodoCertificationDto(dailyTodo, dailyTodoCertification));


### PR DESCRIPTION
- 잘못 설정된 챌린지 그룹 테이블의 시작일, 종료일 컬럼 타입을 date로 정정함.
- 데이터 초기 저장시 updated_at에 값이 삽입되는 문제 해결
- 더이상 사용하지 않는 JPA Auditing 코드 제거

This closes #34 