### PR TITLE
[BE] 성욱님 담당 API 명세 최신화

### DIFF
--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -2,7 +2,7 @@
 == 데일리 투두 API
 
 [[create-daily-todos]]
-=== "데일리 투두 생성 API"
+=== 데일리 투두 생성
 
 ==== 개발 상태
 |===
@@ -24,31 +24,8 @@ include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/request-f
 include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/http-response.adoc[]
 include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/response-fields.adoc[]
 
-[[certify-daily-todo]]
-=== 데일리 투두 수행 인증
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| O
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/http-request.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/path-parameters.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/request-fields.adoc[]
-
-==== HTTP Response
-include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/http-response.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/response-fields.adoc[]
-
 [[get-yesterday-daily-todos]]
-=== 참여중인 특정 챌린지 그룹에서 어제 본인이 작성한 투두 내용 전체 조회 API
+=== 참여중인 특정 챌린지 그룹에서 어제 본인이 작성한 투두 내용 전체 조회
 
 ==== 개발 상태
 |===
@@ -70,7 +47,7 @@ include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/ht
 include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/response-fields.adoc[]
 
 [[get-my-daily-todos]]
-=== 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)
+=== 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 (투두 작성 날짜만 입력)
 
 ==== 개발 상태
 |===
@@ -93,7 +70,7 @@ include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-cert
 include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/response-fields.adoc[]
 
 [[get-my-daily-todos-with-daily-todo-status]]
-=== 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)
+=== 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 (투두 작성 날짜 & 투두 상태 입력)
 
 ==== 개발 상태
 |===

--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -91,3 +91,25 @@ include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-cert
 ==== HTTP Response
 include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/http-response.adoc[]
 include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/response-fields.adoc[]
+
+[[get-challenge-group-member-today-todos]]
+=== 참여중인 특정 챌린지 그룹의 특정 그룹원이 당일 작성한 데일리 투두 전체 조회
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-controller-docs-test/get-challenge-group-member-today-todos/http-request.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-challenge-group-member-today-todos/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-controller-docs-test/get-challenge-group-member-today-todos/http-response.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-challenge-group-member-today-todos/response-fields.adoc[]

--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -2,7 +2,7 @@
 == 데일리 투두 API
 
 [[create-daily-todos]]
-=== 데일리 투두 작성
+=== "데일리 투두 생성 API"
 
 ==== 개발 상태
 |===
@@ -17,6 +17,7 @@
 
 ==== HTTP Request
 include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/http-request.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/path-parameters.adoc[]
 include::{snippets}/daily-todo-controller-docs-test/create-daily-todos/request-fields.adoc[]
 
 ==== HTTP Response

--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -47,7 +47,7 @@ include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/http-resp
 include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/response-fields.adoc[]
 
 [[get-yesterday-daily-todos]]
-=== 어제 작성한 투두 내용 조회
+=== 참여중인 특정 챌린지 그룹에서 어제 본인이 작성한 투두 내용 전체 조회 API
 
 ==== 개발 상태
 |===
@@ -62,13 +62,14 @@ include::{snippets}/daily-todo-controller-docs-test/certify-daily-todo/response-
 
 ==== HTTP Request
 include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/http-request.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/path-parameters.adoc[]
 
 ==== HTTP Response
 include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/http-response.adoc[]
 include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/response-fields.adoc[]
 
 [[get-my-daily-todos]]
-=== 참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)
+=== 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)
 
 ==== 개발 상태
 |===
@@ -91,7 +92,7 @@ include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-cert
 include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/response-fields.adoc[]
 
 [[get-my-daily-todos-with-daily-todo-status]]
-=== 참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)
+=== 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)
 
 ==== 개발 상태
 |===

--- a/src/docs/asciidoc/dailytodo/daily-todo.adoc
+++ b/src/docs/asciidoc/dailytodo/daily-todo.adoc
@@ -68,7 +68,7 @@ include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/ht
 include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/response-fields.adoc[]
 
 [[get-my-daily-todos]]
-=== 내 투두 전체 조회
+=== 참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)
 
 ==== 개발 상태
 |===
@@ -82,15 +82,16 @@ include::{snippets}/daily-todo-controller-docs-test/get-yesterday-daily-todos/re
 |===
 
 ==== HTTP Request
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos/http-request.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos/query-parameters.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/http-request.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/path-parameters.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/query-parameters.adoc[]
 
 ==== HTTP Response
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos/http-response.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos/response-fields.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/http-response.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date/response-fields.adoc[]
 
 [[get-my-daily-todos-with-daily-todo-status]]
-=== 내 투두 상태별 필터링 조회
+=== 참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)
 
 ==== 개발 상태
 |===
@@ -104,9 +105,10 @@ include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos/response-
 |===
 
 ==== HTTP Request
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-daily-todo-status/http-request.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-daily-todo-status/query-parameters.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/http-request.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/path-parameters.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/query-parameters.adoc[]
 
 ==== HTTP Response
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-daily-todo-status/http-response.adoc[]
-include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-daily-todo-status/response-fields.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/http-response.adoc[]
+include::{snippets}/daily-todo-controller-docs-test/get-my-daily-todos-with-certification-input-date-and-todo-status/response-fields.adoc[]

--- a/src/docs/asciidoc/dailytodocertification/daily-todo-certification.adoc
+++ b/src/docs/asciidoc/dailytodocertification/daily-todo-certification.adoc
@@ -1,6 +1,29 @@
 [[daily-todo-certification-api]]
 == 데일리 투두 수행 인증 API
 
+[[certify-daily-todo]]
+=== 데일리 투두 수행 인증 생성
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| O
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/daily-todo-certification-controller-docs-test/certify-daily-todo/http-request.adoc[]
+include::{snippets}/daily-todo-certification-controller-docs-test/certify-daily-todo/path-parameters.adoc[]
+include::{snippets}/daily-todo-certification-controller-docs-test/certify-daily-todo/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/daily-todo-certification-controller-docs-test/certify-daily-todo/http-response.adoc[]
+include::{snippets}/daily-todo-certification-controller-docs-test/certify-daily-todo/response-fields.adoc[]
+
 [[review-daily-todo-certification]]
 === 데일리 투두 수행 인증 검사
 

--- a/src/docs/asciidoc/dailytodocertification/daily-todo-certification.adoc
+++ b/src/docs/asciidoc/dailytodocertification/daily-todo-certification.adoc
@@ -48,7 +48,7 @@ include::{snippets}/daily-todo-certification-controller-docs-test/review-daily-t
 include::{snippets}/daily-todo-certification-controller-docs-test/review-daily-todo-certification/response-fields.adoc[]
 
 [[get-daily-todo-certifications-for-review]]
-=== 검사할 투두 수행 인증 전체 조회
+=== 본인이 검사해 줘야 하는 투두 수행 인증 전체 조회
 
 ==== 개발 상태
 |===
@@ -67,25 +67,3 @@ include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo
 ==== HTTP Response
 include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo-certifications-for-review/http-response.adoc[]
 include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo-certifications-for-review/response-fields.adoc[]
-
-[[get-daily-todo-certification-by-id]]
-=== 특정 투두 수행 인증 상세 조회
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| O
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo-certification-by-id/http-request.adoc[]
-include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo-certification-by-id/path-parameters.adoc[]
-
-==== HTTP Response
-include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo-certification-by-id/http-response.adoc[]
-include::{snippets}/daily-todo-certification-controller-docs-test/get-daily-todo-certification-by-id/response-fields.adoc[]

--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -25,9 +25,10 @@ public class DailyTodoController {
 
     private final DailyTodoService dailyTodoService;
 
-    @PostMapping("/todos")
+    @PostMapping("/challenge-groups/{groupId}/todos")
     public ResponseEntity<ApiResponse<Void>> createDailyTodos(
         @Authenticated Long memberId,
+        @PathVariable Long groupId,
         @RequestBody final CreateDailyTodosRequest request
     ) {
         dailyTodoService.saveDailyTodo(memberId, request.todos());

--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -6,8 +6,10 @@ import org.springframework.web.bind.annotation.*;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.response.ApiResponse;
 import site.dogether.dailytodo.controller.request.CreateDailyTodosRequest;
+import site.dogether.dailytodo.controller.response.GetChallengeMemberTodayTodosResponse;
 import site.dogether.dailytodo.controller.response.GetMyDailyTodosResponse;
 import site.dogether.dailytodo.controller.response.GetYesterdayDailyTodosResponse;
+import site.dogether.dailytodo.entity.DailyTodoStatus;
 import site.dogether.dailytodo.service.DailyTodoService;
 import site.dogether.dailytodo.service.dto.DailyTodoAndDailyTodoCertificationDto;
 import site.dogether.dailytodo.service.dto.FindMyDailyTodosConditionDto;
@@ -57,6 +59,29 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.successWithData(
             GET_MY_DAILY_TODOS,
             GetMyDailyTodosResponse.of(myDailyTodos)
+        ));
+    }
+
+    @GetMapping("/challenge-group-members/{challengeGroupMemberId}/today-todos")
+    public ResponseEntity<ApiResponse<GetChallengeMemberTodayTodosResponse>> getChallengeGroupMemberTodayTodos(
+        @Authenticated Long memberId,
+        @PathVariable final Long groupId,
+        @PathVariable final Long challengeGroupMemberId
+    ) {
+        return ResponseEntity.ok(ApiResponse.successWithData(
+            GET_CHALLENGE_GROUP_MEMBER_TODAY_TODOS,
+            new GetChallengeMemberTodayTodosResponse(
+                "https://승용님_얼짱_각도.png",
+                "승용",
+                76,
+                List.of(
+                    new GetChallengeMemberTodayTodosResponse.TodoData(1L, "신규 기능 개발", DailyTodoStatus.CERTIFY_PENDING, null, null),
+                    new GetChallengeMemberTodayTodosResponse.TodoData(2L, "테스트 코드 작성", DailyTodoStatus.CERTIFY_PENDING, null, null),
+                    new GetChallengeMemberTodayTodosResponse.TodoData(3L, "치킨 먹기", DailyTodoStatus.REVIEW_PENDING, "개꿀맛 치킨 냠냠", "https://치킨.png"),
+                    new GetChallengeMemberTodayTodosResponse.TodoData(4L, "재홍님 갈구기", DailyTodoStatus.APPROVE, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png"),
+                    new GetChallengeMemberTodayTodosResponse.TodoData(5L, "디자인팀 갈구기", DailyTodoStatus.REJECT, "디자인!!!!!!!", "https://갈굼2.png")
+                )
+            )
         ));
     }
 }

--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -19,13 +19,13 @@ import java.util.List;
 import static site.dogether.dailytodo.controller.response.DailyTodoSuccessCode.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/todos")
+@RequestMapping("/api")
 @RestController
 public class DailyTodoController {
 
     private final DailyTodoService dailyTodoService;
 
-    @PostMapping
+    @PostMapping("/todos")
     public ResponseEntity<ApiResponse<Void>> createDailyTodos(
         @Authenticated Long memberId,
         @RequestBody final CreateDailyTodosRequest request
@@ -34,7 +34,7 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.success(CREATE_DAILY_TODOS));
     }
 
-    @PostMapping("/{todoId}/certify")
+    @PostMapping("/todos/{todoId}/certify")
     public ResponseEntity<ApiResponse<Void>> certifyDailyTodo(
         @Authenticated Long memberId,
         @PathVariable final Long todoId,
@@ -44,7 +44,7 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.success(CERTIFY_DAILY_TODO));
     }
 
-    @GetMapping("/my/yesterday")
+    @GetMapping("/todos/my/yesterday")
     public ResponseEntity<ApiResponse<GetYesterdayDailyTodosResponse>> getYesterdayDailyTodos(
         @Authenticated Long memberId
     ) {
@@ -53,9 +53,10 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.successWithData(GET_YESTERDAY_DAILY_TODOS, response));
     }
 
-    @GetMapping("/my")
-    public ResponseEntity<ApiResponse<GetMyDailyTodosResponse>> getMyDailyTodos(
+    @GetMapping("/challenge-groups/{groupId}/my-todos")
+    public ResponseEntity<ApiResponse<GetMyDailyTodosResponse>> getMyDailyTodosWithCertification(
         @Authenticated Long memberId,
+        @PathVariable final Long groupId,
         @RequestParam final LocalDate date,
         @RequestParam(required = false) final String status
     ) {

--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -44,9 +44,10 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.success(CERTIFY_DAILY_TODO));
     }
 
-    @GetMapping("/todos/my/yesterday")
+    @GetMapping("/challenge-groups/{groupId}/my-yesterday-todos")
     public ResponseEntity<ApiResponse<GetYesterdayDailyTodosResponse>> getYesterdayDailyTodos(
-        @Authenticated Long memberId
+        @Authenticated Long memberId,
+        @PathVariable Long groupId
     ) {
         final List<String> yesterdayDailyTodos = dailyTodoService.findYesterdayDailyTodos(memberId);
         final GetYesterdayDailyTodosResponse response = new GetYesterdayDailyTodosResponse(yesterdayDailyTodos);

--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.response.ApiResponse;
-import site.dogether.dailytodo.controller.request.CertifyDailyTodoRequest;
 import site.dogether.dailytodo.controller.request.CreateDailyTodosRequest;
 import site.dogether.dailytodo.controller.response.GetMyDailyTodosResponse;
 import site.dogether.dailytodo.controller.response.GetYesterdayDailyTodosResponse;
@@ -19,13 +18,13 @@ import java.util.List;
 import static site.dogether.dailytodo.controller.response.DailyTodoSuccessCode.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/challenge-groups/{groupId}")
 @RestController
 public class DailyTodoController {
 
     private final DailyTodoService dailyTodoService;
 
-    @PostMapping("/challenge-groups/{groupId}/todos")
+    @PostMapping("/todos")
     public ResponseEntity<ApiResponse<Void>> createDailyTodos(
         @Authenticated Long memberId,
         @PathVariable Long groupId,
@@ -35,17 +34,7 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.success(CREATE_DAILY_TODOS));
     }
 
-    @PostMapping("/todos/{todoId}/certify")
-    public ResponseEntity<ApiResponse<Void>> certifyDailyTodo(
-        @Authenticated Long memberId,
-        @PathVariable final Long todoId,
-        @RequestBody final CertifyDailyTodoRequest request
-    ) {
-        dailyTodoService.certifyDailyTodo(memberId, todoId, request.content(), request.mediaUrls());
-        return ResponseEntity.ok(ApiResponse.success(CERTIFY_DAILY_TODO));
-    }
-
-    @GetMapping("/challenge-groups/{groupId}/my-yesterday-todos")
+    @GetMapping("/my-yesterday-todos")
     public ResponseEntity<ApiResponse<GetYesterdayDailyTodosResponse>> getYesterdayDailyTodos(
         @Authenticated Long memberId,
         @PathVariable Long groupId
@@ -55,7 +44,7 @@ public class DailyTodoController {
         return ResponseEntity.ok(ApiResponse.successWithData(GET_YESTERDAY_DAILY_TODOS, response));
     }
 
-    @GetMapping("/challenge-groups/{groupId}/my-todos")
+    @GetMapping("/my-todos")
     public ResponseEntity<ApiResponse<GetMyDailyTodosResponse>> getMyDailyTodosWithCertification(
         @Authenticated Long memberId,
         @PathVariable final Long groupId,

--- a/src/main/java/site/dogether/dailytodo/controller/request/CertifyDailyTodoRequest.java
+++ b/src/main/java/site/dogether/dailytodo/controller/request/CertifyDailyTodoRequest.java
@@ -1,6 +1,0 @@
-package site.dogether.dailytodo.controller.request;
-
-import java.util.List;
-
-public record CertifyDailyTodoRequest(String content, List<String> mediaUrls) {
-}

--- a/src/main/java/site/dogether/dailytodo/controller/response/DailyTodoSuccessCode.java
+++ b/src/main/java/site/dogether/dailytodo/controller/response/DailyTodoSuccessCode.java
@@ -12,6 +12,7 @@ public enum DailyTodoSuccessCode implements SuccessCode {
     CERTIFY_DAILY_TODO("DTS-0002", "데일리 투두 수행 인증이 완료되었습니다."),
     GET_YESTERDAY_DAILY_TODOS("DTS-0003", "어제 작성된 데일리 투두 내용들이 조회되었습니다."),
     GET_MY_DAILY_TODOS("DTS-0004", "내 데일리 투두들이 조회되었습니다."),
+    GET_CHALLENGE_GROUP_MEMBER_TODAY_TODOS("DTS-0005", "챌린지 그룹원의 당일 투두가 조회되었습니다."),
     ;
 
     private final String value;

--- a/src/main/java/site/dogether/dailytodo/controller/response/GetChallengeMemberTodayTodosResponse.java
+++ b/src/main/java/site/dogether/dailytodo/controller/response/GetChallengeMemberTodayTodosResponse.java
@@ -1,0 +1,24 @@
+package site.dogether.dailytodo.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import site.dogether.dailytodo.entity.DailyTodoStatus;
+
+import java.util.List;
+
+public record GetChallengeMemberTodayTodosResponse(
+    String memberProfileImageUrl,
+    String memberName,
+    int achievementRate,
+    List<TodoData> todos
+) {
+    public record TodoData(
+        Long id,
+        String content,
+        DailyTodoStatus status,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String certificationContent,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String certificationMediaUrl
+    ) {
+    }
+}

--- a/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
+++ b/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
@@ -82,7 +82,7 @@ public class DailyTodoService {
         final Long memberId,
         final Long dailyTodoId,
         final String certifyContent,
-        final List<String> certifyMediaUrls
+        final String certifyMediaUrl
     ) {
         final DailyTodo dailyTodo = getDailyTodo(dailyTodoId);
         final Member member = memberService.getMember(memberId);
@@ -94,7 +94,7 @@ public class DailyTodoService {
         checkDailyTodoStatusIsCertifyPending(dailyTodo);
         checkDailyTodoCreatedToday(dailyTodo);
 
-        final DailyTodoCertification dailyTodoCertification = DailyTodoCertification.create(certifyContent, dailyTodo, member, certifyMediaUrls.get(0)); // TODO : 이제 인증 사진은 1장만 받으므로 LIST 타입 제거
+        final DailyTodoCertification dailyTodoCertification = DailyTodoCertification.create(certifyContent, dailyTodo, member, certifyMediaUrl);
         final Member dailyTodoCertificationReviewer = pickDailyTodoCertificationReviewer(challengeGroup, member);
         dailyTodoCertificationRepository.save(dailyTodoCertification);
 

--- a/src/main/java/site/dogether/dailytodocertification/controller/DailyTodoCertificationController.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/DailyTodoCertificationController.java
@@ -5,11 +5,10 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.response.ApiResponse;
-import site.dogether.dailytodocertification.controller.request.CertifyDailyTodoRequest;
 import site.dogether.dailytodo.service.DailyTodoService;
+import site.dogether.dailytodocertification.controller.request.CertifyDailyTodoRequest;
 import site.dogether.dailytodocertification.controller.request.ReviewDailyTodoCertificationRequest;
 import site.dogether.dailytodocertification.controller.response.DailyTodoCertificationResponse;
-import site.dogether.dailytodocertification.controller.response.GetDailyTodoCertificationByIdResponse;
 import site.dogether.dailytodocertification.controller.response.GetDailyTodoCertificationsForReviewResponse;
 import site.dogether.dailytodocertification.service.DailyTodoCertificationService;
 import site.dogether.dailytodocertification.service.dto.DailyTodoCertificationDto;
@@ -19,7 +18,8 @@ import java.util.List;
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
 import static site.dogether.dailytodo.controller.response.DailyTodoSuccessCode.CERTIFY_DAILY_TODO;
-import static site.dogether.dailytodocertification.controller.response.DailyTodoCertificationSuccessCode.*;
+import static site.dogether.dailytodocertification.controller.response.DailyTodoCertificationSuccessCode.GET_DAILY_TODO_CERTIFICATIONS_FOR_REVIEW;
+import static site.dogether.dailytodocertification.controller.response.DailyTodoCertificationSuccessCode.REVIEW_DAILY_TODO_CERTIFICATION;
 
 @RequiredArgsConstructor
 @RequestMapping("/api")
@@ -64,13 +64,5 @@ public class DailyTodoCertificationController {
             .collect(collectingAndThen(toList(), GetDailyTodoCertificationsForReviewResponse::new));
 
         return ResponseEntity.ok(ApiResponse.successWithData(GET_DAILY_TODO_CERTIFICATIONS_FOR_REVIEW, response));
-    }
-
-    @GetMapping("/todo-certifications/{todoCertificationId}")
-    public ResponseEntity<ApiResponse<GetDailyTodoCertificationByIdResponse>> getDailyTodoCertificationById(@PathVariable Long todoCertificationId) {
-        final DailyTodoCertificationDto dailyTodoCertification = dailyTodoCertificationService.findTodoCertificationById(todoCertificationId);
-        final GetDailyTodoCertificationByIdResponse response = new GetDailyTodoCertificationByIdResponse(DailyTodoCertificationResponse.of(dailyTodoCertification));
-
-        return ResponseEntity.ok(ApiResponse.successWithData(GET_DAILY_TODO_CERTIFICATION_BY_ID, response));
     }
 }

--- a/src/main/java/site/dogether/dailytodocertification/controller/DailyTodoCertificationController.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/DailyTodoCertificationController.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.response.ApiResponse;
+import site.dogether.dailytodocertification.controller.request.CertifyDailyTodoRequest;
+import site.dogether.dailytodo.service.DailyTodoService;
 import site.dogether.dailytodocertification.controller.request.ReviewDailyTodoCertificationRequest;
 import site.dogether.dailytodocertification.controller.response.DailyTodoCertificationResponse;
 import site.dogether.dailytodocertification.controller.response.GetDailyTodoCertificationByIdResponse;
@@ -16,16 +18,28 @@ import java.util.List;
 
 import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.toList;
+import static site.dogether.dailytodo.controller.response.DailyTodoSuccessCode.CERTIFY_DAILY_TODO;
 import static site.dogether.dailytodocertification.controller.response.DailyTodoCertificationSuccessCode.*;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/todo-certifications")
+@RequestMapping("/api")
 @RestController
 public class DailyTodoCertificationController {
 
+    private final DailyTodoService dailyTodoService;
     private final DailyTodoCertificationService dailyTodoCertificationService;
 
-    @PostMapping("{todoCertificationId}/review")
+    @PostMapping("/todos/{todoId}/certify")
+    public ResponseEntity<ApiResponse<Void>> certifyDailyTodo(
+        @Authenticated Long memberId,
+        @PathVariable final Long todoId,
+        @RequestBody final CertifyDailyTodoRequest request
+    ) {
+        dailyTodoService.certifyDailyTodo(memberId, todoId, request.content(), request.mediaUrl());
+        return ResponseEntity.ok(ApiResponse.success(CERTIFY_DAILY_TODO));
+    }
+
+    @PostMapping("/todo-certifications/{todoCertificationId}/review")
     public ResponseEntity<ApiResponse<Void>> reviewDailyTodoCertification(
         @Authenticated Long memberId,
         @PathVariable Long todoCertificationId,
@@ -40,7 +54,7 @@ public class DailyTodoCertificationController {
         return ResponseEntity.ok(ApiResponse.success(REVIEW_DAILY_TODO_CERTIFICATION));
     }
 
-    @GetMapping("/pending-review")
+    @GetMapping("/todo-certifications/pending-review")
     public ResponseEntity<ApiResponse<GetDailyTodoCertificationsForReviewResponse>> getDailyTodoCertificationsForReview(
         @Authenticated Long memberId
     ) {
@@ -52,7 +66,7 @@ public class DailyTodoCertificationController {
         return ResponseEntity.ok(ApiResponse.successWithData(GET_DAILY_TODO_CERTIFICATIONS_FOR_REVIEW, response));
     }
 
-    @GetMapping("/{todoCertificationId}")
+    @GetMapping("/todo-certifications/{todoCertificationId}")
     public ResponseEntity<ApiResponse<GetDailyTodoCertificationByIdResponse>> getDailyTodoCertificationById(@PathVariable Long todoCertificationId) {
         final DailyTodoCertificationDto dailyTodoCertification = dailyTodoCertificationService.findTodoCertificationById(todoCertificationId);
         final GetDailyTodoCertificationByIdResponse response = new GetDailyTodoCertificationByIdResponse(DailyTodoCertificationResponse.of(dailyTodoCertification));

--- a/src/main/java/site/dogether/dailytodocertification/controller/request/CertifyDailyTodoRequest.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/request/CertifyDailyTodoRequest.java
@@ -1,0 +1,4 @@
+package site.dogether.dailytodocertification.controller.request;
+
+public record CertifyDailyTodoRequest(String content, String mediaUrl) {
+}

--- a/src/main/java/site/dogether/dailytodocertification/controller/response/DailyTodoCertificationResponse.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/response/DailyTodoCertificationResponse.java
@@ -2,12 +2,10 @@ package site.dogether.dailytodocertification.controller.response;
 
 import site.dogether.dailytodocertification.service.dto.DailyTodoCertificationDto;
 
-import java.util.List;
-
 public record DailyTodoCertificationResponse(
     Long id,
     String content,
-    List<String> mediaUrls,
+    String mediaUrl,
     String reviewer,
     String todoContent,
     String doer
@@ -16,7 +14,7 @@ public record DailyTodoCertificationResponse(
         return new DailyTodoCertificationResponse(
             dailyTodoCertificationDto.id(),
             dailyTodoCertificationDto.content(),
-            dailyTodoCertificationDto.mediaUrls(),
+            dailyTodoCertificationDto.mediaUrl(),
             dailyTodoCertificationDto.reviewer(),
             dailyTodoCertificationDto.todoContent(),
             dailyTodoCertificationDto.doer()

--- a/src/main/java/site/dogether/dailytodocertification/controller/response/GetDailyTodoCertificationByIdResponse.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/response/GetDailyTodoCertificationByIdResponse.java
@@ -1,6 +1,0 @@
-package site.dogether.dailytodocertification.controller.response;
-
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-
-public record GetDailyTodoCertificationByIdResponse(@JsonUnwrapped DailyTodoCertificationResponse dailyTodoCertification) {
-}

--- a/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
+++ b/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
@@ -71,19 +71,7 @@ public class DailyTodoCertificationService {
             ChallengeGroupStatus.RUNNING);
 
         return dailyTodoCertificationsForReview.stream()
-            .map(dailyTodoCertification -> DailyTodoCertificationDto.from(
-                dailyTodoCertification,
-                List.of(dailyTodoCertification.getMediaUrl()))) // TODO : 인증 사진을 한 장만 넘길 수 있도록 로직 수정
+            .map(DailyTodoCertificationDto::from)
             .toList();
-    }
-
-    public DailyTodoCertificationDto findTodoCertificationById(final Long todoCertificationId) {
-        final DailyTodoCertification dailyTodoCertification = dailyTodoCertificationRepository.findById(todoCertificationId)
-            .orElseThrow(() -> new DailyTodoCertificationNotFoundException(String.format(("해당 id의 데일리 투두 수행 인증 정보가 존재하지 않습니다. (input : %d)" + todoCertificationId))));
-
-        return DailyTodoCertificationDto.from(
-            dailyTodoCertification,
-            List.of(dailyTodoCertification.getMediaUrl()) // TODO : 인증 사진을 한 장만 넘길 수 있도록 로직 수정
-        );
     }
 }

--- a/src/main/java/site/dogether/dailytodocertification/service/dto/DailyTodoCertificationDto.java
+++ b/src/main/java/site/dogether/dailytodocertification/service/dto/DailyTodoCertificationDto.java
@@ -2,21 +2,19 @@ package site.dogether.dailytodocertification.service.dto;
 
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 
-import java.util.List;
-
 public record DailyTodoCertificationDto(
     Long id,
     String content,
-    List<String> mediaUrls,
+    String mediaUrl,
     String reviewer,
     String todoContent,
     String doer
 ) {
-    public static DailyTodoCertificationDto from(final DailyTodoCertification dailyTodoCertification, final List<String> mediaUrls) {
+    public static DailyTodoCertificationDto from(final DailyTodoCertification dailyTodoCertification) {
         return new DailyTodoCertificationDto(
             dailyTodoCertification.getId(),
             dailyTodoCertification.getContent(),
-            mediaUrls,
+            dailyTodoCertification.getMediaUrl(),
             dailyTodoCertification.getReviewerName(),
             dailyTodoCertification.getDailyTodoContent(),
             dailyTodoCertification.getDoerName()

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -115,7 +115,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING))));
     }
     
-    @DisplayName("어제 작성한 투두 내용 조회 API")
+    @DisplayName("참여중인 특정 챌린지 그룹에서 어제 본인이 작성한 투두 내용 전체 조회 API")
     @Test
     void getYesterdayDailyTodos() throws Exception {
         final List<String> yesterdayTodos = List.of(
@@ -129,11 +129,15 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
             .willReturn(yesterdayTodos);
 
         mockMvc.perform(
-                get("/api/todos/my/yesterday")
+                get("/api/challenge-groups/{groupId}/my-yesterday-todos", 1)
                     .header("Authorization", "Bearer access_token")
                     .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("groupId")
+                        .description("챌린지 그룹 id")
+                        .attributes(constraints("유효한 챌린지 그룹 id만 입력 가능"), pathVariableExample(1))),
                 responseFields(
                     fieldWithPath("code")
                         .description("응답 코드")
@@ -147,7 +151,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.ARRAY))));
     }
 
-    @DisplayName("참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)")
+    @DisplayName("참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)")
     @Test
     void getMyDailyTodosWithCertificationInputDate() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly");
@@ -220,7 +224,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING))));
     }
 
-    @DisplayName("참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)")
+    @DisplayName("참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)")
     @Test
     void getMyDailyTodosWithCertificationInputDateAndTodoStatus() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly");

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -242,4 +242,58 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .description("데일리 투두 인증글 이미지 URL")
                         .type(JsonFieldType.STRING))));
     }
+
+    @DisplayName("참여중인 특정 챌린지 그룹의 특정 그룹원이 당일 작성한 데일리 투두 전체 조회 API")
+    @Test
+    void getChallengeGroupMemberTodayTodos() throws Exception {
+        mockMvc.perform(
+                get("/api/challenge-groups/{groupId}/challenge-group-members/{challengeGroupMemberId}/today-todos", 1, 2)
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("groupId")
+                        .description("챌린지 그룹 id")
+                        .attributes(constraints("유효한 챌린지 그룹 id만 입력 가능"), pathVariableExample(1)),
+                    parameterWithName("challengeGroupMemberId")
+                        .description("조회할 챌린지 그룹 멤버 id")
+                        .attributes(constraints("유효한 챌린지 그룹 멤버 id만 입력 가능"), pathVariableExample(2))),
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.memberProfileImageUrl")
+                        .description("조회한 챌린지 그룹 멤버 프로필 이미지 url")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.memberName")
+                        .description("조회한 챌린지 그룹 멤버 이름")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.achievementRate")
+                        .description("조회한 챌린지 그룹 멤버 달성률")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.todos")
+                        .description("조회한 챌린지 그룹 멤버 투두 리스트")
+                        .type(JsonFieldType.ARRAY),
+                    fieldWithPath("data.todos[].id")
+                        .description("데일리 투두 id")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.todos[].content")
+                        .description("데일리 투두 내용")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todos[].status")
+                        .description("데일리 투두 상태")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todos[].certificationContent")
+                        .description("데일리 투두 인증글 내용")
+                        .optional()
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todos[].certificationMediaUrl")
+                        .description("데일리 투두 인증글 이미지 URL")
+                        .optional()
+                        .type(JsonFieldType.STRING))));
+    }
 }

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -147,9 +147,9 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.ARRAY))));
     }
 
-    @DisplayName("내 투두 전체 조회 API")
+    @DisplayName("참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜만 입력)")
     @Test
-    void getMyDailyTodos() throws Exception {
+    void getMyDailyTodosWithCertificationInputDate() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly");
         final Member reviewer = new Member(2L, "elmo-id", "elmo");
         final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
@@ -174,12 +174,16 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
             .willReturn(dailyTodoAndDailyTodoCertificationDtos);
 
         mockMvc.perform(
-                get("/api/todos/my")
+                get("/api/challenge-groups/{groupId}/my-todos", 1)
                     .param("date", LocalDate.now().toString())
                     .header("Authorization", "Bearer access_token")
                     .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("groupId")
+                        .description("챌린지 그룹 id")
+                        .attributes(constraints("유효한 챌린지 그룹 id만 입력 가능"), pathVariableExample(1))),
                 queryParameters(
                     parameterWithName("date")
                         .description("데일리 투두 날짜")),
@@ -216,9 +220,9 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING))));
     }
 
-    @DisplayName("내 투두 전체 조회 - 투두 상태 필터링 API")
+    @DisplayName("참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API (투두 작성 날짜 & 투두 상태 입력)")
     @Test
-    void getMyDailyTodosWithDailyTodoStatus() throws Exception {
+    void getMyDailyTodosWithCertificationInputDateAndTodoStatus() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly");
         final Member reviewer = new Member(2L, "elmo-id", "elmo");
         final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
@@ -230,13 +234,17 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
             .willReturn(dailyTodoAndDailyTodoCertificationDtos);
 
         mockMvc.perform(
-                get("/api/todos/my")
+                get("/api/challenge-groups/{groupId}/my-todos", 1)
                     .param("date", LocalDate.now().toString())
                     .param("status", DailyTodoStatus.REVIEW_PENDING.name())
                     .header("Authorization", "Bearer access_token")
                     .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("groupId")
+                        .description("챌린지 그룹 id")
+                        .attributes(constraints("유효한 챌린지 그룹 id만 입력 가능"), pathVariableExample(1))),
                 queryParameters(
                     parameterWithName("date")
                         .description("데일리 투두 날짜"),

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -41,7 +41,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
         return new DailyTodoController(dailyTodoService);
     }
 
-    @DisplayName("데일리 투두 작성 API")
+    @DisplayName("데일리 투두 생성 API")
     @Test        
     void createDailyTodos() throws Exception {
         final CreateDailyTodosRequest request = new CreateDailyTodosRequest(List.of(
@@ -51,12 +51,16 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
         ));
 
         mockMvc.perform(
-                post("/api/todos")
+                post("/api/challenge-groups/{groupId}/todos", 1)
                     .header("Authorization", "Bearer access_token")
                     .contentType(MediaType.APPLICATION_JSON_VALUE)
                     .content(convertToJson(request)))
             .andExpect(status().isOk())
             .andDo(createDocument(
+                pathParameters(
+                    parameterWithName("groupId")
+                        .description("챌린지 그룹 id")
+                        .attributes(constraints("유효한 챌린지 그룹 id만 입력 가능"), pathVariableExample(1))),
                 requestFields(
                     fieldWithPath("todos")
                         .description("데일리 투두 리스트")

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -7,7 +7,6 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
 import site.dogether.dailytodo.controller.DailyTodoController;
-import site.dogether.dailytodo.controller.request.CertifyDailyTodoRequest;
 import site.dogether.dailytodo.controller.request.CreateDailyTodosRequest;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodo.entity.DailyTodoStatus;
@@ -77,48 +76,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .description("응답 메시지")
                         .type(JsonFieldType.STRING))));
     }
-    
-    @DisplayName("데일리 투두 수행 인증 API")
-    @Test        
-    void certifyDailyTodo() throws Exception {
-        final long todoId = 1L;
-        final CertifyDailyTodoRequest request = new CertifyDailyTodoRequest(
-            "이 노력, 땀 그 모든것이 내 노력의 증거입니다. 양심 있으면 인정 누르시죠.",
-            List.of(
-                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e1.png",
-                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e2.png"
-            )
-        );
 
-        mockMvc.perform(
-                post("/api/todos/{todoId}/certify", todoId)
-                    .header("Authorization", "Bearer access_token")
-                    .contentType(MediaType.APPLICATION_JSON_VALUE)
-                    .content(convertToJson(request)))
-            .andExpect(status().isOk())
-            .andDo(createDocument(
-                pathParameters(
-                    parameterWithName("todoId")
-                        .description("데일리 투두 id")
-                        .attributes(constraints("존재하는 데일리 투두 id만 입력 가능"), pathVariableExample(todoId))),
-                requestFields(
-                    fieldWithPath("content")
-                        .description("데일리 투두 인증 본문")
-                        .type(JsonFieldType.STRING)
-                        .attributes(constraints("2 ~ 50 길이 문자열")),
-                    fieldWithPath("mediaUrls")
-                        .description("데일리 투두 인증 미디어 리소스")
-                        .type(JsonFieldType.ARRAY)
-                        .attributes(constraints("MVP에서는 이미지를 올린 S3 URL만 입력 가능"))),
-                responseFields(
-                    fieldWithPath("code")
-                        .description("응답 코드")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("message")
-                        .description("응답 메시지")
-                        .type(JsonFieldType.STRING))));
-    }
-    
     @DisplayName("참여중인 특정 챌린지 그룹에서 어제 본인이 작성한 투두 내용 전체 조회 API")
     @Test
     void getYesterdayDailyTodos() throws Exception {

--- a/src/test/java/site/dogether/docs/dailytodocertification/DailyTodoCertificationControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodocertification/DailyTodoCertificationControllerDocsTest.java
@@ -114,17 +114,14 @@ public class DailyTodoCertificationControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING))));
     }
     
-    @DisplayName("검사할 투두 수행 인증 전체 조회 API")
+    @DisplayName("본인이 검사해 줘야 하는 투두 수행 인증 전체 조회 API")
     @Test        
     void getDailyTodoCertificationsForReview() throws Exception {
         final List<DailyTodoCertificationDto> dailyTodoCertificationDtos = List.of(
             new DailyTodoCertificationDto(
                 1L,
                 "이 노력, 땀 그 모든것이 내 노력의 증거입니다. 양심 있으면 인정 누르시죠.",
-                List.of(
-                    "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e1.png",
-                    "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e2.png"
-                ),
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e1.png",
                 "진채영",
                 "유산소 & 무산소 1시간 조지기",
                 "승용차"
@@ -132,10 +129,7 @@ public class DailyTodoCertificationControllerDocsTest extends RestDocsSupport {
             new DailyTodoCertificationDto(
                 2L,
                 "공부까지 갓벽...",
-                List.of(
-                    "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/s1.png",
-                    "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/s2.png"
-                ),
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/s1.png",
                 "문지원",
                 "공부 3시간 조지기",
                 "박지은"
@@ -168,69 +162,15 @@ public class DailyTodoCertificationControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.dailyTodoCertifications[].content")
                         .description("수행 인증 본문")
                         .type(JsonFieldType.STRING),
-                    fieldWithPath("data.dailyTodoCertifications[].mediaUrls")
+                    fieldWithPath("data.dailyTodoCertifications[].mediaUrl")
                         .description("인증에 포함된 미디어 리소스")
-                        .type(JsonFieldType.ARRAY),
+                        .type(JsonFieldType.STRING),
                     fieldWithPath("data.dailyTodoCertifications[].reviewer")
                         .description("투두 수행 검사자 이름"),
                     fieldWithPath("data.dailyTodoCertifications[].todoContent")
                         .description("수행 인증한 투두 내용")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.dailyTodoCertifications[].doer")
-                        .description("투두 수행자 이름"))));
-    }
-
-    @DisplayName("특정 투두 수행 인증 상세 조회 API")
-    @Test
-    void getDailyTodoCertificationById() throws Exception {
-        final long todoCertificationId = 1L;
-        final DailyTodoCertificationDto dailyTodoCertificationDto = new DailyTodoCertificationDto(
-            1L,
-            "이 노력, 땀 그 모든것이 내 노력의 증거입니다. 양심 있으면 인정 누르시죠.",
-            List.of(
-                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e1.png",
-                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/daily-todo-proof-media/mock/e2.png"
-            ),
-            "진채영",
-            "유산소 & 무산소 1시간 조지기",
-            "승용차"
-        );
-
-        given(dailyTodoCertificationService.findTodoCertificationById(todoCertificationId))
-            .willReturn(dailyTodoCertificationDto);
-
-        mockMvc.perform(
-                get("/api/todo-certifications/{todoCertificationId}", todoCertificationId)
-                    .header("Authorization", "Bearer access_token")
-                    .contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk())
-            .andDo(createDocument(
-                pathParameters(
-                    parameterWithName("todoCertificationId")
-                        .description("데일리 투두 인증 id")
-                        .attributes(constraints("등록된 데일리 투두 인증 id만 입력 가능"), pathVariableExample(todoCertificationId))),
-                responseFields(
-                    fieldWithPath("code")
-                        .description("응답 코드")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("message")
-                        .description("응답 메시지")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("data.id")
-                        .description("투두 수행 인증 id")
-                        .type(JsonFieldType.NUMBER),
-                    fieldWithPath("data.content")
-                        .description("수행 인증 본문")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("data.mediaUrls")
-                        .description("인증에 포함된 미디어 리소스")
-                        .type(JsonFieldType.ARRAY),
-                    fieldWithPath("data.reviewer")
-                        .description("투두 수행 검사자 이름"),
-                    fieldWithPath("data.todoContent")
-                        .description("수행 인증한 투두 내용")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("data.doer")
                         .description("투두 수행자 이름"))));
     }
 }


### PR DESCRIPTION
양성욱 담당 API 명세를 최신화하였다.
- 참여중인 특정 챌린지 그룹의 내 데일리 투두 전체 조회 API
- 어제 작성한 데일리 투두 내용 전체 조회 API
- 데일리 투두 생성 API
- 데일리 투두 인증 생성 API
- 검사해야할 데일리 투두 인증 목록 조회 API
- 데일리 투두 인증 검사 API
- 참여중인 특정 챌린지 그룹의 특정 그룹원이 당일 작성한 데일리 투두 전체 조회 API
- 푸시 알림 토큰 저장 API
- 푸시 알림 토큰 삭제 API
- S3 Presigned URL 발급 API

This closes #31 