### PR TITLE
[BE] 서은님 담당 API 명세 최신화

### DIFF
--- a/src/docs/asciidoc/memberactivity/member-activity.adoc
+++ b/src/docs/asciidoc/memberactivity/member-activity.adoc
@@ -1,27 +1,6 @@
 [[member-activity-api]]
 == 사용자 활동 API
 
-[[get-all-Group-Names]]
-=== 참여중인 챌린지 그룹 목록 조회
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| X
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/member-activity-controller-docs-test/get-all-groups-name/http-request.adoc[]
-
-==== HTTP Response
-include::{snippets}/member-activity-controller-docs-test/get-all-groups-name/http-response.adoc[]
-include::{snippets}/member-activity-controller-docs-test/get-all-groups-name/response-fields.adoc[]
-
 [[get-group-activity-stat]]
 === 참여중인 특정 챌린지 그룹 활동 통계 조회
 

--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -23,14 +23,15 @@ public class MemberActivityController {
     public ResponseEntity<ApiResponse<GetAllGroupNamesResponse>> getAllGroupNames(
             @Authenticated Long memberId
     ) {
-        List<GroupNameResponse> groups = List.of(
-                new GroupNameResponse(1L, "성욱이와 친구들"),
-                new GroupNameResponse(2L, "스콘 먹기 챌린지"),
-                new GroupNameResponse(3L, "성욱이의 일기")
+        List<GetAllGroupNamesResponse.GroupNameResponse> groups = List.of(
+                new GetAllGroupNamesResponse.GroupNameResponse(1L, "성욱이와 친구들"),
+                new GetAllGroupNamesResponse.GroupNameResponse(2L, "스콘 먹기 챌린지"),
+                new GetAllGroupNamesResponse.GroupNameResponse(3L, "성욱이의 일기")
         );
+
         GetAllGroupNamesResponse response = new GetAllGroupNamesResponse(groups);
 
-        return ResponseEntity.ok(ApiResponse.successWithData(GET_All_GROUP_NAMES, response));
+        return ResponseEntity.ok(ApiResponse.successWithData(GET_ALL_GROUP_NAMES, response));
     }
 
     @GetMapping("/groups/{groupId}/activity")

--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -19,21 +19,6 @@ import static site.dogether.memberactivity.controller.response.MemberActivitySuc
 @RestController
 public class MemberActivityController {
 
-    @GetMapping("/groups")
-    public ResponseEntity<ApiResponse<GetAllGroupNamesResponse>> getAllGroupNames(
-            @Authenticated Long memberId
-    ) {
-        List<GetAllGroupNamesResponse.GroupNameResponse> groups = List.of(
-                new GetAllGroupNamesResponse.GroupNameResponse(1L, "성욱이와 친구들"),
-                new GetAllGroupNamesResponse.GroupNameResponse(2L, "스콘 먹기 챌린지"),
-                new GetAllGroupNamesResponse.GroupNameResponse(3L, "성욱이의 일기")
-        );
-
-        GetAllGroupNamesResponse response = new GetAllGroupNamesResponse(groups);
-
-        return ResponseEntity.ok(ApiResponse.successWithData(GET_ALL_GROUP_NAMES, response));
-    }
-
     @GetMapping("/groups/{groupId}/activity")
     public ResponseEntity<ApiResponse<GetGroupActivityStatResponse>> getGroupActivityStat(
             @Authenticated final Long memberId, @PathVariable final Long groupId

--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -8,11 +8,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.response.ApiResponse;
-import site.dogether.memberactivity.controller.response.*;
+import site.dogether.memberactivity.controller.response.GetGroupActivityStatResponse;
+import site.dogether.memberactivity.controller.response.GetMemberAllStatsResponse;
 
 import java.util.List;
 
-import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.*;
+import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_GROUP_ACTIVITY_STAT;
+import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_MEMBER_ALL_STATS;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/my")
@@ -23,14 +25,14 @@ public class MemberActivityController {
     public ResponseEntity<ApiResponse<GetGroupActivityStatResponse>> getGroupActivityStat(
             @Authenticated final Long memberId, @PathVariable final Long groupId
     ) {
-        List<CertificationPeriodResponse> certificationPeriods = List.of(
-                new CertificationPeriodResponse(1, 8, 2, 25),
-                new CertificationPeriodResponse(2, 6, 3, 50),
-                new CertificationPeriodResponse(3, 3, 3, 100)
+        List<GetGroupActivityStatResponse.CertificationPeriodResponse> certificationPeriods = List.of(
+                new GetGroupActivityStatResponse.CertificationPeriodResponse(1, 8, 2, 25),
+                new GetGroupActivityStatResponse.CertificationPeriodResponse(2, 6, 3, 50),
+                new GetGroupActivityStatResponse.CertificationPeriodResponse(3, 3, 3, 100)
         );
 
-        RankingResponse ranking = new RankingResponse(10, 3);
-        MemberStatsResponse stats = new MemberStatsResponse(123, 123, 123);
+        GetGroupActivityStatResponse.RankingResponse ranking = new GetGroupActivityStatResponse.RankingResponse(10, 3);
+        GetGroupActivityStatResponse.MemberStatsResponse stats = new GetGroupActivityStatResponse.MemberStatsResponse(123, 123, 123);
 
         GetGroupActivityStatResponse response = new GetGroupActivityStatResponse(
                 "성욱이와 친구들",

--- a/src/main/java/site/dogether/memberactivity/controller/response/CertificationPeriodResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/CertificationPeriodResponse.java
@@ -1,4 +1,0 @@
-package site.dogether.memberactivity.controller.response;
-
-public record CertificationPeriodResponse(int day, int createdCount, int certificatedCount, int certificationRate) {
-}

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetAllGroupNamesResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetAllGroupNamesResponse.java
@@ -3,4 +3,7 @@ package site.dogether.memberactivity.controller.response;
 import java.util.List;
 
 public record GetAllGroupNamesResponse(List<GroupNameResponse> groups) {
+
+    public record GroupNameResponse(Long id, String name) {
+    }
 }

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetAllGroupNamesResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetAllGroupNamesResponse.java
@@ -1,9 +1,0 @@
-package site.dogether.memberactivity.controller.response;
-
-import java.util.List;
-
-public record GetAllGroupNamesResponse(List<GroupNameResponse> groups) {
-
-    public record GroupNameResponse(Long id, String name) {
-    }
-}

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetGroupActivityStatResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetGroupActivityStatResponse.java
@@ -9,4 +9,13 @@ public record GetGroupActivityStatResponse(
         RankingResponse ranking,
         MemberStatsResponse stats
         ) {
+
+        public record CertificationPeriodResponse(int day, int createdCount, int certificatedCount, int certificationRate) {
+        }
+
+        public record RankingResponse(int totalMemberCount, int myRank) {
+        }
+
+        public record MemberStatsResponse(int certificatedCount, int approvedCount, int rejectedCount) {
+        }
 }

--- a/src/main/java/site/dogether/memberactivity/controller/response/GroupNameResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GroupNameResponse.java
@@ -1,4 +1,0 @@
-package site.dogether.memberactivity.controller.response;
-
-public record GroupNameResponse(Long id, String name) {
-}

--- a/src/main/java/site/dogether/memberactivity/controller/response/MemberActivitySuccessCode.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/MemberActivitySuccessCode.java
@@ -8,7 +8,7 @@ import site.dogether.common.controller.response.SuccessCode;
 @RequiredArgsConstructor
 public enum MemberActivitySuccessCode implements SuccessCode {
 
-    GET_All_GROUP_NAMES("CGS-0006", "참여중인 그룹의 이름 목록이 조회되었습니다."),
+    GET_ALL_GROUP_NAMES("CGS-0006", "참여중인 그룹의 이름 목록이 조회되었습니다."),
     GET_GROUP_ACTIVITY_STAT("CGS-0007", "특정 챌린지 그룹의 활동 정보가 조회되었습니다."),
     GET_MEMBER_ALL_STATS("CGS-0008", "사용자의 모든 인증 목록이 조회되었습니다.");
 

--- a/src/main/java/site/dogether/memberactivity/controller/response/MemberStatsResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/MemberStatsResponse.java
@@ -1,4 +1,0 @@
-package site.dogether.memberactivity.controller.response;
-
-public record MemberStatsResponse(int certificatedCount, int approvedCount, int rejectedCount) {
-}

--- a/src/main/java/site/dogether/memberactivity/controller/response/RankingResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/RankingResponse.java
@@ -1,4 +1,0 @@
-package site.dogether.memberactivity.controller.response;
-
-public record RankingResponse(int totalMemberCount, int myRank) {
-}

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -241,8 +241,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.ranking")
                         .description("그룹 내 활동 순위")
-                        .type(JsonFieldType.ARRAY)
-                        .optional(),
+                        .type(JsonFieldType.ARRAY),
                     fieldWithPath("data.ranking[].rank")
                         .description("순위")
                         .type(JsonFieldType.NUMBER),

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -53,11 +53,9 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         .type(JsonFieldType.ARRAY),
                                 fieldWithPath("data.groups[].id")
                                         .description("챌린지 그룹 id")
-                                        .optional()
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.groups[].name")
                                         .description("그룹 이름")
-                                        .optional()
                                         .type(JsonFieldType.STRING))));
     }
 

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -7,9 +7,6 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import site.dogether.docs.util.RestDocsSupport;
 import site.dogether.memberactivity.controller.MemberActivityController;
-import site.dogether.memberactivity.controller.response.*;
-
-import java.util.List;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -88,40 +85,6 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
     @DisplayName("사용자의 활동 통계 및 작성한 인증 목록 전체 조회 API")
     @Test
     void getMemberAllStats() throws Exception {
-        final GetMemberAllStatsResponse.DailyTodoStats stats = new GetMemberAllStatsResponse.DailyTodoStats(
-                5,
-                3,
-                2
-        );
-
-        final List<GetMemberAllStatsResponse.DailyTodoCertifications> certifications = List.of(
-                new GetMemberAllStatsResponse.DailyTodoCertifications(
-                        1L,
-                        "운동 하기",
-                        "REVIEW_PENDING",
-                        "운동 개조짐 ㅋㅋㅋㅋ",
-                        "운동 조지는 짤.png",
-                        null
-                ),
-                new GetMemberAllStatsResponse.DailyTodoCertifications(
-                        2L,
-                        "인강 듣기",
-                        "APPROVE",
-                        "인강 진짜 열심히 들었습니다. ㅎ",
-                        "인강 달리는 짤.png",
-                        null
-                ),
-                new GetMemberAllStatsResponse.DailyTodoCertifications(
-                        3L,
-                        "DND API 구현",
-                        "REJECT",
-                        "API 좀 잘 만든듯 ㅋ",
-                        "API 명세짤.png",
-                        "아 별론데?"
-                )
-        );
-
-        final GetMemberAllStatsResponse response = new GetMemberAllStatsResponse(stats, certifications);
 
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/my/activity")

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -29,23 +29,6 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
     void getGroupActivityStat() throws Exception {
         final long groupId = 1L;
 
-        final List<CertificationPeriodResponse> certificationPeriods = List.of(
-                new CertificationPeriodResponse(1, 8, 2, 25),
-                new CertificationPeriodResponse(2, 6, 3, 50),
-                new CertificationPeriodResponse(3, 3, 3, 100)
-        );
-
-        final RankingResponse ranking = new RankingResponse(10, 3);
-        final MemberStatsResponse stats = new MemberStatsResponse(123, 123, 123);
-
-        final GetGroupActivityStatResponse response = new GetGroupActivityStatResponse(
-                "성욱이와 친구들",
-                "25.02.25",
-                certificationPeriods,
-                ranking,
-                stats
-        );
-
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/my//groups/{groupId}/activity", groupId)
                                 .header("Authorization", "Bearer access_token")

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -110,19 +110,15 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         .type(JsonFieldType.ARRAY),
                                 fieldWithPath("data.certificationPeriods[].day")
                                         .description("일차")
-                                        .optional()
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.certificationPeriods[].createdCount")
                                         .description("작성한 투두 개수")
-                                        .optional()
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.certificationPeriods[].certificatedCount")
                                         .description("인증한 투두 개수")
-                                        .optional()
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.certificationPeriods[].certificationRate")
                                         .description("달성률")
-                                        .optional()
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.ranking.totalMemberCount")
                                         .description("그룹원 수")

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -24,42 +24,6 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
         return new MemberActivityController();
     }
 
-    @DisplayName("참여중인 챌린지 그룹 목록 조회 API")
-    @Test
-    void getAllGroupsName() throws Exception {
-        final List<GetAllGroupNamesResponse.GroupNameResponse> groups = List.of(
-                new GetAllGroupNamesResponse.GroupNameResponse(1L, "성욱이와 친구들"),
-                new GetAllGroupNamesResponse.GroupNameResponse(2L, "스콘 먹기 챌린지"),
-                new GetAllGroupNamesResponse.GroupNameResponse(3L, "성욱이의 일기")
-        );
-
-        final GetAllGroupNamesResponse response = new GetAllGroupNamesResponse(groups);
-
-        mockMvc.perform(
-                        MockMvcRequestBuilders.get("/api/my/groups")
-                                .header("Authorization", "Bearer access_token")
-                                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andDo(createDocument(
-                        responseFields(
-                                fieldWithPath("code")
-                                        .description("응답 코드")
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("message")
-                                        .description("응답 메시지")
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("data.groups")
-                                        .description("그룹 이름 목록")
-                                        .optional()
-                                        .type(JsonFieldType.ARRAY),
-                                fieldWithPath("data.groups[].id")
-                                        .description("챌린지 그룹 id")
-                                        .type(JsonFieldType.NUMBER),
-                                fieldWithPath("data.groups[].name")
-                                        .description("그룹 이름")
-                                        .type(JsonFieldType.STRING))));
-    }
-
     @DisplayName("참여중인 특정 챌린지 그룹 활동 통계 조회 API")
     @Test
     void getGroupActivityStat() throws Exception {

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -27,12 +27,13 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
     @DisplayName("참여중인 챌린지 그룹 목록 조회 API")
     @Test
     void getAllGroupsName() throws Exception {
-        final List<GroupNameResponse> groups = List.of(
-                new GroupNameResponse(1L, "성욱이와 친구들"),
-                new GroupNameResponse(2L, "스콘 먹기 챌린지"),
-                new GroupNameResponse(3L, "성욱이의 일기")
+        final List<GetAllGroupNamesResponse.GroupNameResponse> groups = List.of(
+                new GetAllGroupNamesResponse.GroupNameResponse(1L, "성욱이와 친구들"),
+                new GetAllGroupNamesResponse.GroupNameResponse(2L, "스콘 먹기 챌린지"),
+                new GetAllGroupNamesResponse.GroupNameResponse(3L, "성욱이의 일기")
         );
-        GetAllGroupNamesResponse response = new GetAllGroupNamesResponse(groups);
+
+        final GetAllGroupNamesResponse response = new GetAllGroupNamesResponse(groups);
 
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/my/groups")


### PR DESCRIPTION
## Rest Docs 문서화 한 API
- 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 API
- 참여중인 특정 챌린지 그룹 활동 통계 조회 API
- 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 API

## API 수정사항
- 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 API
    - '참여중인 그룹의 팀원 전체 누적 활동 통계 조회' -> '참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회' 명칭 변경
    - 사용자 프로필 이미지 url 필드로 추가
- 새로운 api 추가
    - 참여중인 챌린지 그룹 목록 조회 API
    - 참여중인 특정 챌린지 그룹 활동 통계 조회 API
    - 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 API
    -> 사용자 활동 API 영역에 추가되었습니다.

This closes #30 