### PR TITLE
[BE] 챌린지 그룹 API 변경사항 반영

### DIFF
--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -66,48 +66,6 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/response-fields.adoc[]
 
-[[get-joining-challenge-group-names]]
-=== 참여중인 챌린지 그룹 목록 조회
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| X
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-names/http-request.adoc[]
-
-==== HTTP Response
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-names/http-response.adoc[]
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-names/response-fields.adoc[]
-
-[[is-joined-challenge-group]]
-=== 챌린지 그룹 참여 여부 조회
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| O
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/challenge-group-controller-docs-test/has-challenge-group/http-request.adoc[]
-
-==== HTTP Response
-include::{snippets}/challenge-group-controller-docs-test/has-challenge-group/http-response.adoc[]
-include::{snippets}/challenge-group-controller-docs-test/has-challenge-group/response-fields.adoc[]
-
 [[get-joining-challenge-group-my-activity-summary]]
 === 참여중인 그룹의 내 누적 활동 통계 조회
 

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -3,8 +3,6 @@ package site.dogether.challengegroup.controller;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.CREATE_CHALLENGE_GROUP;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUPS;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUP_MY_ACTIVITY_SUMMARY;
-import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUP_NAMES;
-import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.HAS_CHALLENGE_GROUP;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.JOIN_CHALLENGE_GROUP;
 import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.LEAVE_CHALLENGE_GROUP;
 import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_GROUP_ACTIVITY_STAT;
@@ -23,21 +21,15 @@ import site.dogether.auth.resolver.Authenticated;
 import site.dogether.challengegroup.controller.request.CreateChallengeGroupRequest;
 import site.dogether.challengegroup.controller.request.JoinChallengeGroupRequest;
 import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRankResponse;
-import site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode;
 import site.dogether.challengegroup.controller.response.CreateChallengeGroupResponse;
 import site.dogether.challengegroup.controller.response.GetChallengeGroupMembersRank;
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupMyActivitySummaryResponse;
-import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupNamesResponse;
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupsResponse;
-import site.dogether.challengegroup.controller.response.GetMyChallengeGroupStatusResponse;
-import site.dogether.challengegroup.controller.response.HasChallengeGroupResponse;
 import site.dogether.challengegroup.controller.response.JoinChallengeGroupResponse;
-import site.dogether.challengegroup.entity.ChallengeGroupStatus;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupMyActivityDto;
-import site.dogether.challengegroup.service.dto.JoiningChallengeGroupName;
 import site.dogether.common.controller.response.ApiResponse;
 
 @RequiredArgsConstructor
@@ -88,33 +80,6 @@ public class ChallengeGroupController {
         );
     }
 
-    @GetMapping("/names/members/me")
-    public ResponseEntity<ApiResponse<GetJoiningChallengeGroupNamesResponse>> getJoiningChallengeGroupNames(
-            @Authenticated final Long memberId
-    ) {
-        final List<JoiningChallengeGroupName> joiningChallengeGroups = List.of(
-                new JoiningChallengeGroupName("켈리와 친구들"),
-                new JoiningChallengeGroupName("폰트와 친구들")
-        );
-        return ResponseEntity.ok(
-            ApiResponse.successWithData(
-                GET_JOINING_CHALLENGE_GROUP_NAMES,
-                new GetJoiningChallengeGroupNamesResponse(joiningChallengeGroups))
-        );
-    }
-
-    @GetMapping("/members/me/joined")
-    public ResponseEntity<ApiResponse<HasChallengeGroupResponse>> hasChallengeGroup(
-            @Authenticated final Long memberId
-    ) {
-        final boolean hasGroup = challengeGroupService.hasChallengeGroup(memberId);
-        return ResponseEntity.ok(
-                ApiResponse.successWithData(
-                        HAS_CHALLENGE_GROUP,
-                        new HasChallengeGroupResponse(hasGroup)
-                ));
-    }
-
     @GetMapping("/summary/my")
     public ResponseEntity<ApiResponse<GetJoiningChallengeGroupMyActivitySummaryResponse>> getJoiningChallengeGroupMyActivitySummary(
             @Authenticated final Long memberId
@@ -142,19 +107,6 @@ public class ChallengeGroupController {
         );
         GetChallengeGroupMembersRank response = new GetChallengeGroupMembersRank(groupMemberRanks);
         return ResponseEntity.ok(ApiResponse.successWithData(GET_GROUP_ACTIVITY_STAT, response));
-    }
-
-    @GetMapping("/my/status")
-    public ResponseEntity<ApiResponse<GetMyChallengeGroupStatusResponse>> getMyChallengeGroupStatus(
-        @Authenticated final Long memberId
-    ) {
-        final ChallengeGroupStatus myChallengeGroupStatus = challengeGroupService.getMyChallengeGroupStatus(memberId);
-        return ResponseEntity.ok(
-            ApiResponse.successWithData(
-                ChallengeGroupSuccessCode.GET_MY_CHALLENGE_GROUP_STATUS,
-                new GetMyChallengeGroupStatusResponse(myChallengeGroupStatus)
-            )
-        );
     }
 
     @DeleteMapping("/leave")

--- a/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
@@ -11,12 +11,9 @@ public enum ChallengeGroupSuccessCode implements SuccessCode {
     CREATE_CHALLENGE_GROUP("CGS-0001", "챌린지 그룹을 생성하였습니다."),
     JOIN_CHALLENGE_GROUP("CGS-0002", "챌린지 그룹에 참여하였습니다."),
     GET_JOINING_CHALLENGE_GROUPS("CGS-0003", "참여중인 챌린지 그룹 정보를 조회하였습니다."),
-    GET_JOINING_CHALLENGE_GROUP_NAMES("CGS-0004", "참여중인 챌린지 그룹 목록을 조회하였습니다."),
-    HAS_CHALLENGE_GROUP("CGS-0005", "챌린지 그룹 참여 여부를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_MY_ACTIVITY_SUMMARY("CGS-0006", "참여중인 그룹의 내 누적 활동 통계 정보를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY("CGS-0007", "참여중인 그룹의 팀 전체 누적 활동 통계 정보를 조회하였습니다."),
     LEAVE_CHALLENGE_GROUP("CGS-0008", "챌린지 그룹을 탈퇴하였습니다."),
-    GET_MY_CHALLENGE_GROUP_STATUS("CGS-0009", "내 챌린지 그룹 상태를 조회하였습니다.")
     ;
 
     private final String value;

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupNamesResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupNamesResponse.java
@@ -1,7 +1,0 @@
-package site.dogether.challengegroup.controller.response;
-
-import java.util.List;
-import site.dogether.challengegroup.service.dto.JoiningChallengeGroupName;
-
-public record GetJoiningChallengeGroupNamesResponse(List<JoiningChallengeGroupName> joiningChallengeGroupNames) {
-}

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetMyChallengeGroupStatusResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetMyChallengeGroupStatusResponse.java
@@ -1,6 +1,0 @@
-package site.dogether.challengegroup.controller.response;
-
-import site.dogether.challengegroup.entity.ChallengeGroupStatus;
-
-public record GetMyChallengeGroupStatusResponse(ChallengeGroupStatus status) {
-}

--- a/src/main/java/site/dogether/challengegroup/controller/response/HasChallengeGroupResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/HasChallengeGroupResponse.java
@@ -1,4 +1,0 @@
-package site.dogether.challengegroup.controller.response;
-
-public record HasChallengeGroupResponse(boolean hasGroup) {
-}

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -13,9 +13,7 @@ import site.dogether.challengegroup.controller.request.CreateChallengeGroupReque
 import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRankResponse;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupMember;
-import site.dogether.challengegroup.entity.ChallengeGroupStatus;
 import site.dogether.challengegroup.exception.InvalidChallengeGroupException;
-import site.dogether.challengegroup.exception.MemberNotInChallengeGroupException;
 import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
@@ -98,7 +96,7 @@ public class ChallengeGroupService {
             );
         }
 
-        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yy.MM.dd");
         final String startAtFormatted = challengeGroup.getStartAt().format(formatter);
         final String endAtFormatted = challengeGroup.getEndAt().format(formatter);
 
@@ -114,8 +112,7 @@ public class ChallengeGroupService {
     public List<JoiningChallengeGroupDto> getJoiningChallengeGroups(final Long memberId) {
         final Member member = memberService.getMember(memberId);
 
-        final ChallengeGroupMember challengeGroupMember =
-                challengeGroupMemberRepository.findByMember(member)
+        final ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.findByMember(member)
                         .orElseThrow(() -> new InvalidChallengeGroupException("그룹에 속해있지 않은 유저입니다."));
         final ChallengeGroup challengeGroup = challengeGroupMember.getChallengeGroup();
         isGroupFinished(challengeGroup);
@@ -129,6 +126,8 @@ public class ChallengeGroupService {
         return List.of(
                 new JoiningChallengeGroupDto(
                     challengeGroup.getName(),
+                    1,
+                    10,
                     challengeGroup.getJoinCode(),
                     endAtFormatted,
                     challengeGroup.getDurationDays()

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -125,6 +125,7 @@ public class ChallengeGroupService {
 
         return List.of(
                 new JoiningChallengeGroupDto(
+                    challengeGroup.getId(),
                     challengeGroup.getName(),
                     1,
                     10,

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -186,18 +186,6 @@ public class ChallengeGroupService {
         return List.of();
     }
 
-    public boolean hasChallengeGroup(final Long memberId) {
-        final Member member = memberService.getMember(memberId);
-        final ChallengeGroupMember challengeGroupMember =
-                challengeGroupMemberRepository.findByMember(member).orElse(null);
-        if (challengeGroupMember == null) {
-            return false;
-        }
-        final ChallengeGroup joiningGroup = challengeGroupMember.getChallengeGroup();
-
-        return !joiningGroup.isFinished();
-    }
-
     @Transactional
     public void leaveChallengeGroup(final Long memberId) {
         final Member member = memberService.getMember(memberId);
@@ -209,12 +197,5 @@ public class ChallengeGroupService {
         isGroupFinished(challengeGroup);
 
         challengeGroupMemberRepository.delete(challengeGroupMember);
-    }
-
-    public ChallengeGroupStatus getMyChallengeGroupStatus(final Long memberId) {
-        final Member member = memberService.getMember(memberId);
-        final ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.findByMember(member)
-            .orElseThrow(() -> new MemberNotInChallengeGroupException("회원이 속한 챌린지 그룹이 존재하지 않습니다."));
-        return challengeGroupMember.getChallengeGroup().getStatus();
     }
 }

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
@@ -1,6 +1,7 @@
 package site.dogether.challengegroup.service.dto;
 
 public record JoiningChallengeGroupDto(
+    Long groupId,
     String groupName,
     int currentMemberCount,
     int maximumMemberCount,

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
@@ -2,6 +2,8 @@ package site.dogether.challengegroup.service.dto;
 
 public record JoiningChallengeGroupDto(
     String groupName,
+    int currentMemberCount,
+    int maximumMemberCount,
     String joinCode,
     String endAt,
     int currentDay

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupName.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupName.java
@@ -1,4 +1,0 @@
-package site.dogether.challengegroup.service.dto;
-
-public record JoiningChallengeGroupName(String groupName) {
-}

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -30,7 +30,6 @@ import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupMyActivityDto;
-import site.dogether.challengegroup.service.dto.JoiningChallengeGroupName;
 import site.dogether.docs.util.RestDocsSupport;
 
 @DisplayName("챌린지 그룹 API 문서화 테스트")
@@ -103,8 +102,8 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     "성욱이와 친구들",
                     3,
                     8,
-                    "2025.03.02",
-                    "2025.03.05"
+                    "25.03.02",
+                    "25.03.05"
             ));
 
         mockMvc.perform(
@@ -147,8 +146,20 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     @Test
     void getJoiningChallengeGroups() throws Exception {
         List<JoiningChallengeGroupDto> joiningChallengeGroups = List.of(
-            new JoiningChallengeGroupDto("폰트의 챌린지", "G3hIj4kLm", "2025.03.05", 5),
-            new JoiningChallengeGroupDto("켈리와 친구들", "A1Bc4dEf", "2025.03.02", 2)
+            new JoiningChallengeGroupDto(
+                    "폰트의 챌린지",
+                    1,
+                    10,
+                    "G3hIj4kLm",
+                    "25.03.05",
+                    5),
+            new JoiningChallengeGroupDto(
+                    "켈리와 친구들",
+                    1,
+                    10,
+                    "A1Bc4dEf",
+                    "25.03.02",
+                    2)
         );
 
         given(challengeGroupService.getJoiningChallengeGroups(any()))
@@ -174,6 +185,12 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.joiningChallengeGroups[].groupName")
                         .description("그룹명")
                         .type(JsonFieldType.STRING),
+                    fieldWithPath("data.joiningChallengeGroups[].currentMemberCount")
+                        .description("현재 인원수")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.joiningChallengeGroups[].maximumMemberCount")
+                        .description("총 인원수")
+                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.joiningChallengeGroups[].joinCode")
                         .description("그룹 참여 코드")
                         .type(JsonFieldType.STRING),

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -147,6 +147,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     void getJoiningChallengeGroups() throws Exception {
         List<JoiningChallengeGroupDto> joiningChallengeGroups = List.of(
             new JoiningChallengeGroupDto(
+                    1L,
                     "폰트의 챌린지",
                     1,
                     10,
@@ -154,6 +155,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     "25.03.05",
                     5),
             new JoiningChallengeGroupDto(
+                    2L,
                     "켈리와 친구들",
                     1,
                     10,
@@ -182,6 +184,9 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .description("참여중인 챌린지 그룹")
                         .type(JsonFieldType.ARRAY)
                         .optional(),
+                    fieldWithPath("data.joiningChallengeGroups[].groupId")
+                        .description("챌린지 그룹 id")
+                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.joiningChallengeGroups[].groupName")
                         .description("그룹명")
                         .type(JsonFieldType.STRING),

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -185,59 +185,6 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.NUMBER))));
     }
 
-    @DisplayName("참여중인 챌린지 그룹 목록 조회 API")
-    @Test
-    void getJoiningChallengeGroupNames() throws Exception {
-        List<JoiningChallengeGroupName> joiningChallengeGroupNames = List.of(
-            new JoiningChallengeGroupName("폰트의 챌린지"), new JoiningChallengeGroupName("켈리와 친구들")
-        );
-
-        mockMvc.perform(
-                get("/api/groups/names/members/me")
-                    .header("Authorization", "Bearer access_token")
-                    .contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(status().isOk())
-            .andDo(createDocument(
-                responseFields(
-                    fieldWithPath("code")
-                        .description("응답 코드")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("message")
-                        .description("응답 메시지")
-                        .type(JsonFieldType.STRING),
-                    fieldWithPath("data.joiningChallengeGroupNames")
-                        .description("참여중인 챌린지 그룹 목록")
-                        .type(JsonFieldType.ARRAY)
-                        .optional(),
-                    fieldWithPath("data.joiningChallengeGroupNames[].groupName")
-                        .description("그룹명")
-                        .type(JsonFieldType.STRING))));
-    }
-
-    @DisplayName("챌린지 그룹 참여 여부 조회 API")
-    @Test
-    void hasChallengeGroup() throws Exception {
-        given(challengeGroupService.hasChallengeGroup(any()))
-                .willReturn(true);
-
-        mockMvc.perform(
-                        get("/api/groups/members/me/joined")
-                                .header("Authorization", "Bearer access_token")
-                                .contentType(MediaType.APPLICATION_JSON_VALUE))
-                .andExpect(status().isOk())
-                .andDo(createDocument(
-                        responseFields(
-                                fieldWithPath("code")
-                                        .description("응답 코드")
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("message")
-                                        .description("응답 메시지")
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("data.hasGroup")
-                                        .description("그룹에 참여중인지 여부")
-                                        .type(JsonFieldType.BOOLEAN))));
-    }
-
     @DisplayName("참여중인 그룹의 내 누적 활동 통계 조회 API")
     @Test
     void getJoiningChallengeGroupMyActivitySummary() throws Exception {


### PR DESCRIPTION
4.22 회의 후 챌린지 그룹 API 명세를 수정합니다.
- 불필요한 API 삭제
    - 챌린지 그룹 목록 조회 API 삭제 -> 전체 조회 API만 사용합니다.
    - 챌린지 그룹 참여 여부 API 삭제 -> 참여중인 그룹이 없다면 참여하고 있지 않음이 판단 가능해서 따로 API가 필요 없습니다.
    - 챌린지 그룹 상태 조회 API 삭제
- 참여중인 그룹 전체 조회 API 필드 수정
    - 챌린지 그룹 페이지 변경에 따라 현재 인원 수, 총 인원 수 필드를 추가합니다.
    - 년도 양식을 변경합니다. (2025.01.01 -> 25.01.01)
    - 챌린지 그룹을 식별할 수 있는 id 값을 포함합니다.