### PR TITLE
[BE] 회원 탈퇴 시 연관 데이터 논리 삭제 기능 구현

### DIFF
--- a/src/main/java/site/dogether/auth/service/AuthService.java
+++ b/src/main/java/site/dogether/auth/service/AuthService.java
@@ -45,6 +45,7 @@ public class AuthService {
         final boolean isRevoked = appleOAuthProvider.revoke(request.authorizationCode());
         if (isRevoked) {
             memberWithdrawService.delete(memberId);
+            log.info("회원 탈퇴 처리 완료. memberId: {}", memberId);
         }
     }
 

--- a/src/main/java/site/dogether/auth/service/AuthService.java
+++ b/src/main/java/site/dogether/auth/service/AuthService.java
@@ -11,6 +11,7 @@ import site.dogether.auth.oauth.AppleOAuthProvider;
 import site.dogether.auth.oauth.JwtHandler;
 import site.dogether.member.entity.Member;
 import site.dogether.member.service.MemberService;
+import site.dogether.member.service.MemberWithdrawService;
 import site.dogether.member.service.dto.AuthenticatedMember;
 
 @Slf4j
@@ -22,6 +23,7 @@ public class AuthService {
     private final JwtHandler jwtHandler;
     private final AppleOAuthProvider appleOAuthProvider;
     private final MemberService memberService;
+    private final MemberWithdrawService memberWithdrawService;
 
     @Transactional
     public AuthenticatedMember login(final LoginRequest request) {
@@ -38,9 +40,9 @@ public class AuthService {
 
     @Transactional
     public void withdraw(final Long memberId, final WithdrawRequest request) {
-        boolean isRevoked = appleOAuthProvider.revoke(request.authorizationCode());
+        final boolean isRevoked = appleOAuthProvider.revoke(request.authorizationCode());
         if (isRevoked) {
-            memberService.delete(memberId);
+            memberWithdrawService.delete(memberId);
         }
     }
 

--- a/src/main/java/site/dogether/auth/service/AuthService.java
+++ b/src/main/java/site/dogether/auth/service/AuthService.java
@@ -27,10 +27,12 @@ public class AuthService {
 
     @Transactional
     public AuthenticatedMember login(final LoginRequest request) {
+        log.info("로그인 요청을 받습니다. idToken: {}", request.idToken());
+
         final String subject = appleOAuthProvider.parseSubject(request.idToken());
         log.info("subject of apple idToken 을 파싱합니다. sub: {}", subject);
 
-        final Member savedMember = memberService.save(Member.create(subject, request.name()));
+        final Member savedMember = memberService.save(subject, request.name());
         log.info("회원을 저장 or 조회합니다. providerId: {}", savedMember.getProviderId());
 
         final String authenticationToken = jwtHandler.createToken(savedMember.getId());

--- a/src/main/java/site/dogether/challengegroup/repository/ChallengeGroupMemberRepository.java
+++ b/src/main/java/site/dogether/challengegroup/repository/ChallengeGroupMemberRepository.java
@@ -33,6 +33,8 @@ public interface ChallengeGroupMemberRepository extends JpaRepository<ChallengeG
             """)
     List<ChallengeGroupMember> findNotFinishedGroupByMember(Member member);
 
+    List<ChallengeGroupMember> findAllByMember(Member member);
+
     Optional<ChallengeGroupMember> findByMember(Member member);
 
     Optional<ChallengeGroupMember> findByChallengeGroup_StatusAndMember(ChallengeGroupStatus challengeGroupStatus, Member member);

--- a/src/main/java/site/dogether/common/audit/entity/BaseEntity.java
+++ b/src/main/java/site/dogether/common/audit/entity/BaseEntity.java
@@ -1,9 +1,11 @@
 package site.dogether.common.audit.entity;
 
-import jakarta.persistence.*;
-import lombok.Getter;
-
+import jakarta.persistence.Column;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
 import java.time.LocalDateTime;
+import lombok.Getter;
 
 @Getter
 @MappedSuperclass
@@ -27,5 +29,9 @@ public class BaseEntity {
     @PreUpdate
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
     }
 }

--- a/src/main/java/site/dogether/dailytodo/repository/DailyTodoRepository.java
+++ b/src/main/java/site/dogether/dailytodo/repository/DailyTodoRepository.java
@@ -1,13 +1,12 @@
 package site.dogether.dailytodo.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import site.dogether.challengegroup.entity.ChallengeGroup;
-import site.dogether.dailytodo.entity.DailyTodoStatus;
-import site.dogether.dailytodo.entity.DailyTodo;
-import site.dogether.member.entity.Member;
-
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.dogether.challengegroup.entity.ChallengeGroup;
+import site.dogether.dailytodo.entity.DailyTodo;
+import site.dogether.dailytodo.entity.DailyTodoStatus;
+import site.dogether.member.entity.Member;
 
 public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
 
@@ -35,4 +34,6 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
         LocalDateTime endDateTime,
         DailyTodoStatus status
     );
+
+    List<DailyTodo> findAllByMember(Member member);
 }

--- a/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
+++ b/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
@@ -1,14 +1,13 @@
 package site.dogether.dailytodocertification.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import site.dogether.challengegroup.entity.ChallengeGroupStatus;
-import site.dogether.dailytodo.entity.DailyTodoStatus;
-import site.dogether.dailytodo.entity.DailyTodo;
-import site.dogether.dailytodocertification.entity.DailyTodoCertification;
-import site.dogether.member.entity.Member;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.dailytodo.entity.DailyTodo;
+import site.dogether.dailytodo.entity.DailyTodoStatus;
+import site.dogether.dailytodocertification.entity.DailyTodoCertification;
+import site.dogether.member.entity.Member;
 
 public interface DailyTodoCertificationRepository extends JpaRepository<DailyTodoCertification, Long> {
 
@@ -21,4 +20,6 @@ public interface DailyTodoCertificationRepository extends JpaRepository<DailyTod
     );
 
     Optional<DailyTodoCertification> findByDailyTodo(final DailyTodo dailyTodo);
+
+    List<DailyTodoCertification> findAllByReviewer(Member member);
 }

--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -48,7 +48,7 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<ChallengeGroupMember> challengeGroupMembers;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "reviewer", cascade = CascadeType.REMOVE)
     private List<DailyTodoCertification> dailyTodoCertifications;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)

--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
@@ -18,6 +19,7 @@ import site.dogether.common.audit.entity.BaseEntity;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.member.exception.InvalidMemberException;
+import site.dogether.memberactivity.entity.DailyTodoStats;
 import site.dogether.notification.entity.NotificationTokenJpaEntity;
 
 @ToString
@@ -51,6 +53,9 @@ public class Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<DailyTodo> dailyTodos;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private DailyTodoStats dailyTodoStats;
 
     public static Member create(final String providerId, final String name) {
         return new Member(null, providerId, name, saveRandomProfileImageUrl());

--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -1,18 +1,24 @@
 package site.dogether.member.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import site.dogether.challengegroup.entity.ChallengeGroupMember;
 import site.dogether.common.audit.entity.BaseEntity;
+import site.dogether.dailytodo.entity.DailyTodo;
+import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.member.exception.InvalidMemberException;
+import site.dogether.notification.entity.NotificationTokenJpaEntity;
 
 @ToString
 @Getter
@@ -33,6 +39,18 @@ public class Member extends BaseEntity {
 
     @Column(name = "profile_image_url", length = 500, nullable = false)
     private String profileImageUrl;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<NotificationTokenJpaEntity> notificationTokens;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<ChallengeGroupMember> challengeGroupMembers;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<DailyTodoCertification> dailyTodoCertifications;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<DailyTodo> dailyTodos;
 
     public static Member create(final String providerId, final String name) {
         return new Member(null, providerId, name, saveRandomProfileImageUrl());

--- a/src/main/java/site/dogether/member/service/MemberService.java
+++ b/src/main/java/site/dogether/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package site.dogether.member.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,15 +18,27 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     @Transactional
-    public Member save(final Member member) {
-        return memberRepository.findByProviderId(member.getProviderId())
-            .orElseGet(() -> memberRepository.save(member));
+    public Member save(final String providerId, final String name) {
+        Optional<Member> found = memberRepository.findByProviderId(providerId);
+
+        if (found.isPresent()) {
+            Member member = found.get();
+            if (!member.isDeleted()) {
+                return member;
+            }
+            hardDelete(member);
+            return createMember(providerId, name);
+        }
+        return createMember(providerId, name);
     }
 
-    @Transactional
-    public void delete(final Long memberId) {
-        final Member member = getMember(memberId);
+    private void hardDelete(Member member) {
         memberRepository.delete(member);
+    }
+
+    private Member createMember(String providerId, String name) {
+        Member newMember = Member.create(providerId, name);
+        return memberRepository.save(newMember);
     }
 
     public Member getMember(final Long memberId) {

--- a/src/main/java/site/dogether/member/service/MemberService.java
+++ b/src/main/java/site/dogether/member/service/MemberService.java
@@ -24,15 +24,18 @@ public class MemberService {
         if (found.isPresent()) {
             Member member = found.get();
             if (!member.isDeleted()) {
+                log.info("가입한 회원을 조회합니다. memberId: {}", member.getId());
                 return member;
             }
             hardDelete(member);
             return createMember(providerId, name);
         }
+        log.info("신규 가입 회원을 저장합니다. providerId: {}", providerId);
         return createMember(providerId, name);
     }
 
     private void hardDelete(Member member) {
+        log.info("재가입을 위한 회원 정보 삭제. memberId: {}", member.getId());
         memberRepository.delete(member);
     }
 

--- a/src/main/java/site/dogether/member/service/MemberWithdrawService.java
+++ b/src/main/java/site/dogether/member/service/MemberWithdrawService.java
@@ -1,0 +1,42 @@
+package site.dogether.member.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
+import site.dogether.common.audit.entity.BaseEntity;
+import site.dogether.dailytodo.repository.DailyTodoRepository;
+import site.dogether.dailytodocertification.repository.DailyTodoCertificationRepository;
+import site.dogether.member.entity.Member;
+import site.dogether.notification.repository.NotificationTokenJpaRepository;
+
+@Slf4j
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class MemberWithdrawService {
+
+    private final MemberService memberService;
+    private final NotificationTokenJpaRepository notificationTokenJpaRepository;
+    private final ChallengeGroupMemberRepository challengeGroupMemberRepository;
+    private final DailyTodoRepository dailyTodoRepository;
+    private final DailyTodoCertificationRepository dailyTodoCertificationRepository;
+
+    @Transactional
+    public void delete(final Long memberId) {
+        final Member member = memberService.getMember(memberId);
+        member.softDelete();
+
+        challengeGroupMemberRepository.findAllByMember(member)
+                .forEach(BaseEntity::softDelete);
+        notificationTokenJpaRepository.findAllByMember(member)
+                .forEach(BaseEntity::softDelete);
+        dailyTodoRepository.findAllByMember(member)
+                .forEach(BaseEntity::softDelete);
+        dailyTodoCertificationRepository.findAllByReviewer(member)
+                .forEach(BaseEntity::softDelete);
+
+        log.info("회원 탈퇴 처리 완료. memberId: {}", memberId);
+    }
+}

--- a/src/main/java/site/dogether/member/service/MemberWithdrawService.java
+++ b/src/main/java/site/dogether/member/service/MemberWithdrawService.java
@@ -27,16 +27,19 @@ public class MemberWithdrawService {
     public void delete(final Long memberId) {
         final Member member = memberService.getMember(memberId);
         member.softDelete();
+        log.info("회원 컬럼 soft delete. memberId: {}", memberId);
 
         challengeGroupMemberRepository.findAllByMember(member)
                 .forEach(BaseEntity::softDelete);
+        log.info("회원의 챌린지 그룹 멤버 컬럼 soft delete");
         notificationTokenJpaRepository.findAllByMember(member)
                 .forEach(BaseEntity::softDelete);
+        log.info("회원의 알림 토큰 컬럼 soft delete");
         dailyTodoRepository.findAllByMember(member)
                 .forEach(BaseEntity::softDelete);
+        log.info("회원의 데일리 투두 컬럼 soft delete");
         dailyTodoCertificationRepository.findAllByReviewer(member)
                 .forEach(BaseEntity::softDelete);
-
-        log.info("회원 탈퇴 처리 완료. memberId: {}", memberId);
+        log.info("회원의 데일리 투두 인증 컬럼 soft delete");
     }
 }

--- a/src/main/java/site/dogether/member/service/MemberWithdrawService.java
+++ b/src/main/java/site/dogether/member/service/MemberWithdrawService.java
@@ -9,6 +9,7 @@ import site.dogether.common.audit.entity.BaseEntity;
 import site.dogether.dailytodo.repository.DailyTodoRepository;
 import site.dogether.dailytodocertification.repository.DailyTodoCertificationRepository;
 import site.dogether.member.entity.Member;
+import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
 import site.dogether.notification.repository.NotificationTokenJpaRepository;
 
 @Slf4j
@@ -22,6 +23,7 @@ public class MemberWithdrawService {
     private final ChallengeGroupMemberRepository challengeGroupMemberRepository;
     private final DailyTodoRepository dailyTodoRepository;
     private final DailyTodoCertificationRepository dailyTodoCertificationRepository;
+    private final DailyTodoStatsRepository dailyTodoStatsRepository;
 
     @Transactional
     public void delete(final Long memberId) {
@@ -32,14 +34,21 @@ public class MemberWithdrawService {
         challengeGroupMemberRepository.findAllByMember(member)
                 .forEach(BaseEntity::softDelete);
         log.info("회원의 챌린지 그룹 멤버 컬럼 soft delete");
+
         notificationTokenJpaRepository.findAllByMember(member)
                 .forEach(BaseEntity::softDelete);
         log.info("회원의 알림 토큰 컬럼 soft delete");
+
         dailyTodoRepository.findAllByMember(member)
                 .forEach(BaseEntity::softDelete);
         log.info("회원의 데일리 투두 컬럼 soft delete");
+
         dailyTodoCertificationRepository.findAllByReviewer(member)
                 .forEach(BaseEntity::softDelete);
         log.info("회원의 데일리 투두 인증 컬럼 soft delete");
+
+        dailyTodoStatsRepository.findByMember(member)
+                .ifPresent(BaseEntity::softDelete);
+        log.info("회원의 데일리 투두 통계 컬럼 soft delete");
     }
 }

--- a/src/main/java/site/dogether/memberactivity/repository/DailyTodoStatsRepository.java
+++ b/src/main/java/site/dogether/memberactivity/repository/DailyTodoStatsRepository.java
@@ -1,7 +1,11 @@
 package site.dogether.memberactivity.repository;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import site.dogether.member.entity.Member;
 import site.dogether.memberactivity.entity.DailyTodoStats;
 
 public interface DailyTodoStatsRepository extends JpaRepository<DailyTodoStats, Long> {
+
+    Optional<DailyTodoStats> findByMember(Member member);
 }

--- a/src/main/java/site/dogether/notification/repository/NotificationTokenJpaRepository.java
+++ b/src/main/java/site/dogether/notification/repository/NotificationTokenJpaRepository.java
@@ -1,11 +1,10 @@
 package site.dogether.notification.repository;
 
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.dogether.member.entity.Member;
 import site.dogether.notification.entity.NotificationTokenJpaEntity;
-
-import java.util.List;
-import java.util.Optional;
 
 public interface NotificationTokenJpaRepository extends JpaRepository<NotificationTokenJpaEntity, Long> {
 
@@ -16,4 +15,6 @@ public interface NotificationTokenJpaRepository extends JpaRepository<Notificati
     boolean existsByMemberAndValue(Member member, String value);
 
     Optional<NotificationTokenJpaEntity> findByMemberAndValue(Member member, String value);
+
+    List<NotificationTokenJpaEntity> findAllByMember(Member member);
 }


### PR DESCRIPTION
- 회원 탈퇴 시 연관된 테이블의 is_deleted 컬럼을 true로 바꿉니다. 
    - 연관 테이블 : 
       `notification_token`, `challenge_group_member,` `daily_todo`, `daily_todo_stats`, `daily_todo_certificaiton`

- 논리 삭제된 회원이 재가입할 시 물리 삭제 후 새로 회원을 등록합니다.
- 물리 삭제는 회원의 자식 테이블을 모두 cascadeType을 remove 로 설정하여 삭제합니다.
- 회원 탈퇴 로직에서 MemberService가 다른 도메인을 모두 의존하기 때문에 순환참조 방지를 위해 MemberWithdrawService를 따로 둡니다.