### PR TITLE
[BE] 챌린지 그룹 종료일 상태 추가, 조회 응답 필드 변경

### DIFF
--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -66,27 +66,6 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/response-fields.adoc[]
 
-[[get-joining-challenge-group-my-activity-summary]]
-=== 참여중인 그룹의 내 누적 활동 통계 조회
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| O
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-my-activity-summary/http-request.adoc[]
-
-==== HTTP Response
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-my-activity-summary/http-response.adoc[]
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-my-activity-summary/response-fields.adoc[]
-
 [[get-joining-challenge-group-team-activity-summary]]
 === 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회
 
@@ -125,6 +104,7 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 
 ==== HTTP Request
 include::{snippets}/challenge-group-controller-docs-test/leave-challenge-group/http-request.adoc[]
+include::{snippets}/challenge-group-controller-docs-test/leave-challenge-group/path-parameters.adoc[]
 
 ==== HTTP Response
 include::{snippets}/challenge-group-controller-docs-test/leave-challenge-group/http-response.adoc[]

--- a/src/docs/asciidoc/enum/challenge-group-status.adoc
+++ b/src/docs/asciidoc/enum/challenge-group-status.adoc
@@ -1,0 +1,5 @@
+:doctype: book
+:icons: font
+
+[[challenge-group-status]]
+include::{snippets}/common-docs-controller-test/enums/custom-response-fields-beneath-challengeGroupStatus.adoc[]

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -1,21 +1,33 @@
 package site.dogether.challengegroup.controller;
 
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.CREATE_CHALLENGE_GROUP;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUPS;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.JOIN_CHALLENGE_GROUP;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.LEAVE_CHALLENGE_GROUP;
+import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_GROUP_ACTIVITY_STAT;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.challengegroup.controller.request.CreateChallengeGroupRequest;
 import site.dogether.challengegroup.controller.request.JoinChallengeGroupRequest;
-import site.dogether.challengegroup.controller.response.*;
+import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRankResponse;
+import site.dogether.challengegroup.controller.response.CreateChallengeGroupResponse;
+import site.dogether.challengegroup.controller.response.GetChallengeGroupMembersRank;
+import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupsResponse;
+import site.dogether.challengegroup.controller.response.JoinChallengeGroupResponse;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 import site.dogether.common.controller.response.ApiResponse;
-
-import java.util.List;
-
-import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.*;
-import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_GROUP_ACTIVITY_STAT;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
@@ -31,9 +43,9 @@ public class ChallengeGroupController {
     ) {
         final String joinCode = challengeGroupService.createChallengeGroup(request, memberId);
         return ResponseEntity.ok(
-                ApiResponse.successWithData(
-                        CREATE_CHALLENGE_GROUP,
-                        new CreateChallengeGroupResponse(joinCode)));
+            ApiResponse.successWithData(
+                CREATE_CHALLENGE_GROUP,
+                new CreateChallengeGroupResponse(joinCode)));
     }
 
     @PostMapping("/join")
@@ -41,7 +53,7 @@ public class ChallengeGroupController {
             @Authenticated final Long memberId,
             @RequestBody final JoinChallengeGroupRequest request
     ) {
-        JoinChallengeGroupDto joinChallengeGroupDto = challengeGroupService.joinChallengeGroup(request.joinCode(), memberId);
+        final JoinChallengeGroupDto joinChallengeGroupDto = challengeGroupService.joinChallengeGroup(request.joinCode(), memberId);
         return ResponseEntity.ok(
             ApiResponse.successWithData(
                 JOIN_CHALLENGE_GROUP,

--- a/src/main/java/site/dogether/challengegroup/controller/response/JoinChallengeGroupResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/JoinChallengeGroupResponse.java
@@ -4,7 +4,6 @@ import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 
 public record JoinChallengeGroupResponse(
     String groupName,
-    int duration,
     int maximumMemberCount,
     String startAt,
     String endAt
@@ -12,7 +11,6 @@ public record JoinChallengeGroupResponse(
     public static JoinChallengeGroupResponse from(JoinChallengeGroupDto joinChallengeGroupDto) {
         return new JoinChallengeGroupResponse(
             joinChallengeGroupDto.groupName(),
-            joinChallengeGroupDto.duration(),
             joinChallengeGroupDto.maximumMemberCount(),
             joinChallengeGroupDto.startAt(),
             joinChallengeGroupDto.endAt()

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -120,23 +121,33 @@ public class ChallengeGroup extends BaseEntity {
 
     // TODO : startAT이 endAt보다 늦은 날짜가 아닌지 검증
 
+
     public boolean isFinished() {
         return this.status == ChallengeGroupStatus.FINISHED;
-    }
-
-    public int getDurationDays() {
-        return endAt.getDayOfYear() - startAt.getDayOfYear();
     }
 
     public boolean isRunning() {
         return status == ChallengeGroupStatus.RUNNING;
     }
 
-    public int getCurrentDay() {
-        return LocalDate.now().getDayOfYear() - startAt.getDayOfYear();
+    public int getProgressDay() {
+        LocalDate today = LocalDate.now();
+        if (today.isBefore(startAt)) {
+            return 0;
+        }
+        return (int) ChronoUnit.DAYS.between(startAt, today) + 1;
     }
 
     public double getProgressRate() {
-        return (double) getCurrentDay() / getDurationDays();
+        int progressDay = getProgressDay();
+        int duration = getDuration();
+        if (progressDay > duration) {
+            return 1;
+        }
+        return (double) progressDay / duration;
+    }
+
+    private int getDuration() {
+        return (int) ChronoUnit.DAYS.between(startAt, endAt);
     }
 }

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -58,6 +58,7 @@ public class ChallengeGroup extends BaseEntity {
         final LocalDate startAt,
         final LocalDate endAt
     ) {
+        validateEndAtIsAfterStartAt(startAt, endAt);
         return new ChallengeGroup(
             null,
             validateGroupNameLength(name),
@@ -67,6 +68,14 @@ public class ChallengeGroup extends BaseEntity {
             generateJoinCode(),
             setStatus(startAt)
         );
+    }
+
+    private static void validateEndAtIsAfterStartAt(LocalDate startAt, LocalDate endAt) {
+        if (startAt.isAfter(endAt)) {
+            throw new InvalidChallengeGroupException(
+                    String.format("시작일은 종료일보다 늦을 수 없습니다. (startAt : %s, endAt : %s)", startAt, endAt)
+            );
+        }
     }
 
     private static int validateMaximumMemberCount(int maximumMemberCount) {
@@ -118,9 +127,6 @@ public class ChallengeGroup extends BaseEntity {
         this.joinCode = joinCode;
         this.status = status;
     }
-
-    // TODO : startAT이 endAt보다 늦은 날짜가 아닌지 검증
-
 
     public boolean isFinished() {
         return this.status == ChallengeGroupStatus.FINISHED;

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupStatus.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupStatus.java
@@ -4,6 +4,7 @@ public enum ChallengeGroupStatus {
 
     READY,
     RUNNING,
+    D_DAY,
     FINISHED
     ;
 }

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -1,5 +1,8 @@
 package site.dogether.challengegroup.service;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,10 +31,6 @@ import site.dogether.dailytodo.service.DailyTodoService;
 import site.dogether.member.entity.Member;
 import site.dogether.member.service.MemberService;
 import site.dogether.notification.service.NotificationService;
-
-import java.time.LocalDate;
-import java.util.List;
-import java.util.stream.IntStream;
 
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoinChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoinChallengeGroupDto.java
@@ -5,7 +5,6 @@ import site.dogether.challengegroup.entity.ChallengeGroup;
 
 public record JoinChallengeGroupDto(
         String groupName,
-        int duration,
         int maximumMemberCount,
         String startAt,
         String endAt
@@ -17,7 +16,6 @@ public record JoinChallengeGroupDto(
 
         return new JoinChallengeGroupDto(
                 challengeGroup.getName(),
-                challengeGroup.getDurationDays(),
                 challengeGroup.getMaximumMemberCount(),
                 startAtFormatted,
                 endAtFormatted

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
@@ -30,7 +30,7 @@ public record JoiningChallengeGroupDto(
             joiningGroup.getStatus().name(),
             joiningGroup.getStartAt().format(formatter),
             joiningGroup.getEndAt().format(formatter),
-            joiningGroup.getCurrentDay(),
+            joiningGroup.getProgressDay(),
             joiningGroup.getProgressRate()
         );
     }

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
@@ -10,6 +10,7 @@ public record JoiningChallengeGroupDto(
     int maximumMemberCount,
     String joinCode,
     String status,
+    String startAt,
     String endAt,
     int progressDay,
     double progressRate
@@ -27,6 +28,7 @@ public record JoiningChallengeGroupDto(
             joiningGroup.getMaximumMemberCount(),
             joiningGroup.getJoinCode(),
             joiningGroup.getStatus().name(),
+            joiningGroup.getStartAt().format(formatter),
             joiningGroup.getEndAt().format(formatter),
             joiningGroup.getCurrentDay(),
             joiningGroup.getProgressRate()

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -1,5 +1,23 @@
 package site.dogether.docs.challengegroup;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_DURATION_OPTION;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_START_AT_OPTION;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_STATUS;
+import static site.dogether.docs.util.DocumentLinkGenerator.generateLink;
+
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -11,22 +29,7 @@ import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRank
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
-
 import site.dogether.docs.util.RestDocsSupport;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_DURATION_OPTION;
-import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_START_AT_OPTION;
-import static site.dogether.docs.util.DocumentLinkGenerator.generateLink;
 
 @DisplayName("챌린지 그룹 API 문서화 테스트")
 public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
@@ -96,7 +99,6 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
         given(challengeGroupService.joinChallengeGroup(any(), any()))
             .willReturn(new JoinChallengeGroupDto(
                     "성욱이와 친구들",
-                    3,
                     8,
                     "25.03.02",
                     "25.03.05"
@@ -109,8 +111,14 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     .content(convertToJson(request)))
             .andExpect(status().isOk())
             .andDo(createDocument(
+                requestFields(
+                    fieldWithPath("joinCode")
+                    .description("참여 코드")
+                    .type(JsonFieldType.STRING)
+                    .attributes(constraints("서버에서 발급한 숫자,영문 포함 8자리 코드"))),
                 responseFields(
-                    fieldWithPath("code").description("응답 코드")
+                    fieldWithPath("code")
+                        .description("응답 코드")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("message")
                         .description("응답 메시지")
@@ -118,9 +126,6 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.groupName")
                         .description("그룹명")
                         .type(JsonFieldType.STRING),
-                    fieldWithPath("data.duration")
-                        .description("챌린지 기간")
-                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.maximumMemberCount")
                         .description("총 인원수")
                         .type(JsonFieldType.NUMBER),
@@ -143,6 +148,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     10,
                     "G3hIj4kLm",
                     "RUNNING",
+                    "25.03.02",
                     "25.03.05",
                     5,
                     0.3),
@@ -152,8 +158,9 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     1,
                     10,
                     "A1Bc4dEf",
-                    "RUNNING",
+                    "D_DAY",
                     "25.03.02",
+                    "25.03.05",
                     2,
                     0.5)
         );
@@ -194,7 +201,11 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .description("그룹 참여 코드")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.joiningChallengeGroups[].status")
-                        .description("챌린지 그룹 상태")
+                        .description(generateLink(CHALLENGE_GROUP_STATUS))
+                        .type(JsonFieldType.STRING)
+                        .attributes(constraints("정해진 값만 입력 허용")),
+                    fieldWithPath("data.joiningChallengeGroups[].startAt")
+                        .description("챌린지 시작일")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.joiningChallengeGroups[].endAt")
                         .description("챌린지 종료일")
@@ -221,7 +232,8 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                 .andDo(createDocument(
                     pathParameters(
                         parameterWithName("groupId")
-                            .description("탈퇴할 챌린지 그룹의 ID")),
+                            .description("탈퇴할 챌린지 그룹의 ID")
+                                .attributes(constraints("존재하는 챌린지 그룹 id만 입력 가능"), pathVariableExample(groupId))),
                     responseFields(
                         fieldWithPath("code")
                             .description("응답 코드")

--- a/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupStatusDocs.java
+++ b/src/test/java/site/dogether/docs/challengegroup/enumtype/ChallengeGroupStatusDocs.java
@@ -1,0 +1,27 @@
+package site.dogether.docs.challengegroup.enumtype;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.docs.util.RestDocsEnumType;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChallengeGroupStatusDocs implements RestDocsEnumType {
+
+    READY("시작 대기", "READY"),
+    RUNNING("진행중", "RUNNING"),
+    D_DAY("종료일", "D_DAY"),
+    FINISHED("종료일도 지남", "FINISHED"),;
+
+    private static final int enumValueCount = ChallengeGroupStatus.values().length;
+
+    private final String description;
+    private final String requestValue;
+
+    public static RestDocsEnumType[] getValues() {
+        final ChallengeGroupStatusDocs[] values = ChallengeGroupStatusDocs.values();
+        RestDocsEnumType.checkDocsValueCountIsEqualToEnumValueCount(enumValueCount, values.length);
+        return values;
+    }
+}

--- a/src/test/java/site/dogether/docs/util/CommonDocsController.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsController.java
@@ -1,18 +1,18 @@
 package site.dogether.docs.util;
 
+import static java.util.stream.Collectors.toMap;
+
+import java.util.Arrays;
+import java.util.Map;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import site.dogether.docs.challengegroup.enumtype.ChallengeGroupDurationOptionDocs;
 import site.dogether.docs.challengegroup.enumtype.ChallengeGroupStartAtOptionDocs;
+import site.dogether.docs.challengegroup.enumtype.ChallengeGroupStatusDocs;
 import site.dogether.docs.dailytodo.enumtype.DailyTodoStatusDocs;
 import site.dogether.docs.dailytodocertification.enumtype.DailyTodoCertificationReviewResultDocs;
 import site.dogether.docs.s3.enumtype.S3UploadFileTypeDocs;
-
-import java.util.Arrays;
-import java.util.Map;
-
-import static java.util.stream.Collectors.toMap;
 
 @RequestMapping("/test")
 @RestController
@@ -22,12 +22,14 @@ public class CommonDocsController {
     public EnumDocs findEnums() {
         final Map<String, String> challengeGroupStartAtOption = convertToMap(ChallengeGroupStartAtOptionDocs.getValues());
         final Map<String, String> challengeGroupDurationOption = convertToMap(ChallengeGroupDurationOptionDocs.getValues());
+        final Map<String, String> challengeGroupStatus = convertToMap(ChallengeGroupStatusDocs.getValues());
         final Map<String, String> dailyTodoCertificationReviewResult = convertToMap(DailyTodoCertificationReviewResultDocs.getValues());
         final Map<String, String> s3UploadFileType = convertToMap(S3UploadFileTypeDocs.getValues());
         final Map<String, String> dailyTodoStatus = convertToMap(DailyTodoStatusDocs.getValues());
         return EnumDocs.builder()
             .challengeGroupStartAtOption(challengeGroupStartAtOption)
             .challengeGroupDurationOption(challengeGroupDurationOption)
+            .challengeGroupStatus(challengeGroupStatus)
             .dailyTodoCertificationReviewResult(dailyTodoCertificationReviewResult)
             .s3UploadFileType(s3UploadFileType)
             .dailyTodoStatus(dailyTodoStatus)

--- a/src/test/java/site/dogether/docs/util/CommonDocsControllerTest.java
+++ b/src/test/java/site/dogether/docs/util/CommonDocsControllerTest.java
@@ -1,6 +1,15 @@
 package site.dogether.docs.util;
 
+import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
+import static org.springframework.restdocs.snippet.Attributes.attributes;
+import static org.springframework.restdocs.snippet.Attributes.key;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -9,16 +18,6 @@ import org.springframework.restdocs.payload.PayloadDocumentation;
 import org.springframework.restdocs.payload.PayloadSubsectionExtractor;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Map;
-
-import static org.springframework.restdocs.payload.PayloadDocumentation.beneathPath;
-import static org.springframework.restdocs.snippet.Attributes.attributes;
-import static org.springframework.restdocs.snippet.Attributes.key;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @DisplayName("API 문서화 util 테스트")
 public class CommonDocsControllerTest extends RestDocsSupport {
@@ -44,6 +43,9 @@ public class CommonDocsControllerTest extends RestDocsSupport {
                 customResponseFields("custom-response", beneathPath("challengeGroupDurationOption"),
                     attributes(key("title").value("그룹 진행 기간 옵션")),
                     convertEnumToFieldDescriptor((enumDocs.getChallengeGroupDurationOption()))),
+                customResponseFields("custom-response", beneathPath("challengeGroupStatus"),
+                    attributes(key("title").value("그룹 상태 타입")),
+                    convertEnumToFieldDescriptor((enumDocs.getChallengeGroupStatus()))),
                 customResponseFields("custom-response", beneathPath("dailyTodoCertificationReviewResult"),
                     attributes(key("title").value("데일리 투두 수행 인증 검사 결과 옵션")),
                     convertEnumToFieldDescriptor((enumDocs.getDailyTodoCertificationReviewResult()))),

--- a/src/test/java/site/dogether/docs/util/DocumentLinkGenerator.java
+++ b/src/test/java/site/dogether/docs/util/DocumentLinkGenerator.java
@@ -9,6 +9,7 @@ public final class DocumentLinkGenerator {
     public enum DocUrl {
         CHALLENGE_GROUP_START_AT_OPTION("challenge-group-start-at-option", "그룹 시작일 옵션"),
         CHALLENGE_GROUP_DURATION_OPTION("challenge-group-duration-option", "그룹 진행 기간 옵션"),
+        CHALLENGE_GROUP_STATUS("challenge-group-status", "그룹 상태 타입"),
         DAILY_TODO_CERTIFICATION_REVIEW_RESULT("daily-todo-certification-review-result", "데일리 투두 수행 인증 검사 결과 옵션"),
         S3_UPLOAD_FILE_TYPE("s3-upload-file-type", "S3 업로드 파일 타입 옵션"),
         DAILY_TODO_STATUS("daily-todo-status", "데일리 투두 상태 옵션"),

--- a/src/test/java/site/dogether/docs/util/EnumDocs.java
+++ b/src/test/java/site/dogether/docs/util/EnumDocs.java
@@ -1,8 +1,10 @@
 package site.dogether.docs.util;
 
-import lombok.*;
-
 import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
@@ -12,6 +14,7 @@ public class EnumDocs {
 
     Map<String, String> challengeGroupStartAtOption;
     Map<String, String> challengeGroupDurationOption;
+    Map<String, String> challengeGroupStatus;
     Map<String, String> dailyTodoCertificationReviewResult;
     Map<String, String> s3UploadFileType;
     Map<String, String> dailyTodoStatus;


### PR DESCRIPTION
### 변경 사항
- 챌린지 그룹 상태 추가
    - 종료일 당일의 상태를 표현하기 위해 ChallengeGroupStatus enum 필드에 D_DAY 상태 필드 추가
    - RestDocs에 그룹 상태 enum docs 추가
- 챌린지 그룹 조회 API 응답 필드 수정
    - 마지막 인증일일때 progressRate가 1.0이도록 로직 수정
    - startAt 필드 추가