### PR TITLE
[BE] 담당 API 명세 업데이트

### DIFF
--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -66,27 +66,6 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/response-fields.adoc[]
 
-[[get-joining-challenge-group-my-activity-summary]]
-=== 참여중인 그룹의 내 누적 활동 통계 조회
-
-==== 개발 상태
-|===
-| 환경 | 구현 여부
-
-| 개발
-| O
-
-| 운영
-| X
-|===
-
-==== HTTP Request
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-my-activity-summary/http-request.adoc[]
-
-==== HTTP Response
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-my-activity-summary/http-response.adoc[]
-include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-group-my-activity-summary/response-fields.adoc[]
-
 [[get-joining-challenge-group-team-activity-summary]]
 === 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회
 

--- a/src/docs/asciidoc/memberactivity/member-activity.adoc
+++ b/src/docs/asciidoc/memberactivity/member-activity.adoc
@@ -23,8 +23,8 @@ include::{snippets}/member-activity-controller-docs-test/get-group-activity-stat
 include::{snippets}/member-activity-controller-docs-test/get-group-activity-stat/http-response.adoc[]
 include::{snippets}/member-activity-controller-docs-test/get-group-activity-stat/response-fields.adoc[]
 
-[[get-member-all-stats]]
-=== 사용자의 활동 통계 및 작성한 인증 목록 전체 조회
+[[get-member-all-stats-sorted-by-todo-completed-at]]
+=== 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 (투두 완료일 순)
 
 ==== 개발 상태
 |===
@@ -38,8 +38,31 @@ include::{snippets}/member-activity-controller-docs-test/get-group-activity-stat
 |===
 
 ==== HTTP Request
-include::{snippets}/member-activity-controller-docs-test/get-member-all-stats/http-request.adoc[]
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-todo-completed-at/http-request.adoc[]
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-todo-completed-at/query-parameters.adoc[]
 
 ==== HTTP Response
-include::{snippets}/member-activity-controller-docs-test/get-member-all-stats/http-response.adoc[]
-include::{snippets}/member-activity-controller-docs-test/get-member-all-stats/response-fields.adoc[]
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-todo-completed-at/http-response.adoc[]
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-todo-completed-at/response-fields.adoc[]
+
+[[get-member-all-stats-sorted-by-group-created-at]]
+=== 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 (그룹 생성일 순)
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-group-created-at/http-request.adoc[]
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-group-created-at/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-group-created-at/http-response.adoc[]
+include::{snippets}/member-activity-controller-docs-test/get-member-all-stats-sorted-by-group-created-at/response-fields.adoc[]

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -71,6 +71,7 @@ public class ChallengeGroupController {
         ));
     }
 
+    // TODO: memberId 별로 랭킹 조회하도록 수정 예정
     @GetMapping("/{groupId}/ranking")
     public ResponseEntity<ApiResponse<GetChallengeGroupMembersRank>> getJoiningChallengeGroupTeamRanking(
             @PathVariable Long groupId

--- a/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupMemberRankResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupMemberRankResponse.java
@@ -12,14 +12,16 @@ public class ChallengeGroupMemberRankResponse {
     private int rank;
     private String profileImageUrl;
     private String name;
+    private String historyReadStatus;
     private int achievementRate;
 
-    public static ChallengeGroupMemberRankResponse from(Long memberId, RankDto rankDto, String profileImageUrl) {
+    public static ChallengeGroupMemberRankResponse from(Long memberId, RankDto rankDto, String profileImageUrl, String historyReadStatus) {
         return ChallengeGroupMemberRankResponse.builder()
                 .memberId(memberId)
                 .rank(rankDto.getRank())
                 .profileImageUrl(profileImageUrl)
                 .name(rankDto.getName())
+                .historyReadStatus(historyReadStatus)
                 .achievementRate(rankDto.getAchievementRate())
                 .build();
     }

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -163,6 +163,7 @@ public class ChallengeGroupService {
         }
     }
 
+    // TODO: historyReadStatus 필드 추가 예정 (history 테이블 생성 후 작업 예정)
     public List<ChallengeGroupMemberRankResponse> getChallengeGroupRanking(final Long groupId) {
         final ChallengeGroup challengeGroup = challengeGroupRepository.findById(groupId)
                 .orElseThrow(() -> new InvalidChallengeGroupException("해당 그룹이 존재하지 않습니다."));
@@ -183,7 +184,8 @@ public class ChallengeGroupService {
                 .mapToObj(i -> ChallengeGroupMemberRankResponse.from(
                         memberIds.get(i),
                         memberRanks.get(i),
-                        profileImageUrls.get(i)
+                        profileImageUrls.get(i),
+                        "READYET"
                 ))
                 .toList();
     }

--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -25,6 +25,8 @@ public class MemberActivityController {
     public ResponseEntity<ApiResponse<GetGroupActivityStatResponse>> getGroupActivityStat(
             @Authenticated final Long memberId, @PathVariable final Long groupId
     ) {
+        GetGroupActivityStatResponse.ChallengeGroupInfoResponse groupInfo = new GetGroupActivityStatResponse.ChallengeGroupInfoResponse("그로밋과 함께하는 챌린지", 10, 6, "123456", "25.02.22");
+
         List<GetGroupActivityStatResponse.CertificationPeriodResponse> certificationPeriods = List.of(
                 new GetGroupActivityStatResponse.CertificationPeriodResponse(1, 8, 2, 25),
                 new GetGroupActivityStatResponse.CertificationPeriodResponse(2, 6, 3, 50),
@@ -35,8 +37,7 @@ public class MemberActivityController {
         GetGroupActivityStatResponse.MemberStatsResponse stats = new GetGroupActivityStatResponse.MemberStatsResponse(123, 123, 123);
 
         GetGroupActivityStatResponse response = new GetGroupActivityStatResponse(
-                "성욱이와 친구들",
-                "25.02.25",
+                groupInfo,
                 certificationPeriods,
                 ranking,
                 stats

--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.response.ApiResponse;
@@ -48,7 +49,9 @@ public class MemberActivityController {
 
     @GetMapping("/activity")
     public ResponseEntity<ApiResponse<GetMemberAllStatsResponse>> getMemberAllStats(
-            @Authenticated final Long memberId
+            @Authenticated final Long memberId,
+            @RequestParam(name = "sort", defaultValue = "todo-completed-at") final String sort,
+            @RequestParam final String status
     ) {
         GetMemberAllStatsResponse.DailyTodoStats stats = new GetMemberAllStatsResponse.DailyTodoStats(
                 5,
@@ -56,32 +59,110 @@ public class MemberActivityController {
                 2
         );
 
-        List<GetMemberAllStatsResponse.DailyTodoCertifications> certifications = List.of(
-                new GetMemberAllStatsResponse.DailyTodoCertifications(
-                        1L,
-                        "운동 하기",
-                        "REVIEW_PENDING",
-                        "운동 개조짐 ㅋㅋㅋㅋ",
-                        "운동 조지는 짤.png",
-                        null
-                ),
-                new GetMemberAllStatsResponse.DailyTodoCertifications(
-                        2L,
-                        "인강 듣기",
-                        "APPROVE",
-                        "인강 진짜 열심히 들었습니다. ㅎ",
-                        "인강 달리는 짤.png",
-                        null
-                ),
-                new GetMemberAllStatsResponse.DailyTodoCertifications(
-                        3L,
-                        "DND API 구현",
-                        "REJECT",
-                        "API 좀 잘 만든듯 ㅋ",
-                        "API 명세짤.png",
-                        "아 별론데?"
-                )
-        );
+        List<GetMemberAllStatsResponse.DailyTodoCertifications> certifications;
+
+        if(sort.equals("todo-completed-at")) {
+            certifications = List.of(
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            1L,
+                            null,
+                            "2025.04.30",
+                            "운동 하기",
+                            "APPROVE",
+                            "운동 개조짐 ㅋㅋㅋㅋ",
+                            "운동 조지는 짤.png",
+                            null
+                    ),
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            2L,
+                            null,
+                            "2025.04.31",
+                            "인강 듣기",
+                            "APPROVE",
+                            "인강 진짜 열심히 들었습니다. ㅎ",
+                            "인강 달리는 짤.png",
+                            null
+                    ),
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            3L,
+                            null,
+                            "2025.04.31",
+                            "두게더 API 구현",
+                            "APPROVE",
+                            "API 좀 잘 만든듯 ㅋ",
+                            "API 명세짤.png",
+                            null
+                    )
+            );
+        }
+        else if(sort.equals("group-created-at")) {
+            certifications = List.of(
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            1L,
+                            "스쿼트 챌린지",
+                            null,
+                            "운동 하기",
+                            "REJECT",
+                            "운동 개조짐 ㅋㅋㅋㅋ",
+                            "운동 조지는 짤.png",
+                            "에이 이건 운동 아니지"
+                    ),
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            2L,
+                            "TIL 챌린지",
+                            null,
+                            "인강 듣기",
+                            "REJECT",
+                            "인강 진짜 열심히 들었습니다. ㅎ",
+                            "인강 달리는 짤.png",
+                            "우리 오늘 인강 듣는날 아닌데?"
+                    ),
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            3L,
+                            "두게더 개발단",
+                            null,
+                            "두게더 API 구현",
+                            "REJECT",
+                            "API 좀 잘 만든듯 ㅋ",
+                            "API 명세짤.png",
+                            "아 별론데?"
+                    )
+            );
+        }
+        else {
+            certifications = List.of(
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            1L,
+                            null,
+                            null,
+                            "운동 하기",
+                            "REVIEW_PENDING",
+                            "운동 개조짐 ㅋㅋㅋㅋ",
+                            "운동 조지는 짤.png",
+                            null
+                    ),
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            2L,
+                            null,
+                            null,
+                            "인강 듣기",
+                            "REVIEW_PENDING",
+                            "인강 진짜 열심히 들었습니다. ㅎ",
+                            "인강 달리는 짤.png",
+                            null
+                    ),
+                    new GetMemberAllStatsResponse.DailyTodoCertifications(
+                            3L,
+                            null,
+                            null,
+                            "두게더 API 구현",
+                            "REVIEW_PENDING",
+                            "API 좀 잘 만든듯 ㅋ",
+                            "API 명세짤.png",
+                            null
+                    )
+            );
+        }
 
         GetMemberAllStatsResponse response = new GetMemberAllStatsResponse(stats, certifications);
 

--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -31,7 +31,8 @@ public class MemberActivityController {
         List<GetGroupActivityStatResponse.CertificationPeriodResponse> certificationPeriods = List.of(
                 new GetGroupActivityStatResponse.CertificationPeriodResponse(1, 8, 2, 25),
                 new GetGroupActivityStatResponse.CertificationPeriodResponse(2, 6, 3, 50),
-                new GetGroupActivityStatResponse.CertificationPeriodResponse(3, 3, 3, 100)
+                new GetGroupActivityStatResponse.CertificationPeriodResponse(3, 6, 3, 50),
+                new GetGroupActivityStatResponse.CertificationPeriodResponse(4, 3, 3, 100)
         );
 
         GetGroupActivityStatResponse.RankingResponse ranking = new GetGroupActivityStatResponse.RankingResponse(10, 3);
@@ -59,112 +60,70 @@ public class MemberActivityController {
                 2
         );
 
-        List<GetMemberAllStatsResponse.DailyTodoCertifications> certifications;
+        List<Object> dailyTodoCertifications = null;
 
         if(sort.equals("todo-completed-at")) {
-            certifications = List.of(
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            1L,
-                            null,
-                            "2025.04.30",
-                            "운동 하기",
-                            "APPROVE",
-                            "운동 개조짐 ㅋㅋㅋㅋ",
-                            "운동 조지는 짤.png",
-                            null
+            dailyTodoCertifications = List.of(
+                    new GetMemberAllStatsResponse.CertificationsSortByTodoCompletedAt(
+                            "2025.05.01",
+                            List.of(
+                                    new GetMemberAllStatsResponse.DailyTodoCertificationInfo(
+                                            1L,
+                                            "운동 하기",
+                                            "REJECT",
+                                            "운동 개조짐 ㅋㅋㅋㅋ",
+                                            "운동 조지는 짤.png",
+                                            "에이 이건 운동 아니지"
+                                    )
+                            )
                     ),
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            2L,
-                            null,
-                            "2025.04.31",
-                            "인강 듣기",
-                            "APPROVE",
-                            "인강 진짜 열심히 들었습니다. ㅎ",
-                            "인강 달리는 짤.png",
-                            null
-                    ),
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            3L,
-                            null,
-                            "2025.04.31",
-                            "두게더 API 구현",
-                            "APPROVE",
-                            "API 좀 잘 만든듯 ㅋ",
-                            "API 명세짤.png",
-                            null
+                    new GetMemberAllStatsResponse.CertificationsSortByTodoCompletedAt(
+                            "2025.05.02",
+                            List.of(
+                                    new GetMemberAllStatsResponse.DailyTodoCertificationInfo(
+                                            2L,
+                                            "인강 듣기",
+                                            "REJECT",
+                                            "인강 진짜 열심히 들었습니다. ㅎ",
+                                            "인강 달리는 짤.png",
+                                            "우리 오늘 인강 듣는날 아닌데?"
+                                    )
+                            )
                     )
             );
         }
-        else if(sort.equals("group-created-at")) {
-            certifications = List.of(
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            1L,
+        else if (sort.equals("group-created-at")) {
+            dailyTodoCertifications = List.of(
+                    new GetMemberAllStatsResponse.CertificationsSortByGroupCreatedAt(
                             "스쿼트 챌린지",
-                            null,
-                            "운동 하기",
-                            "REJECT",
-                            "운동 개조짐 ㅋㅋㅋㅋ",
-                            "운동 조지는 짤.png",
-                            "에이 이건 운동 아니지"
+                            List.of(
+                                    new GetMemberAllStatsResponse.DailyTodoCertificationInfo(
+                                            1L,
+                                            "운동 하기",
+                                            "REJECT",
+                                            "운동 개조짐 ㅋㅋㅋㅋ",
+                                            "운동 조지는 짤.png",
+                                            "에이 이건 운동 아니지"
+                                    )
+                            )
                     ),
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            2L,
+                    new GetMemberAllStatsResponse.CertificationsSortByGroupCreatedAt(
                             "TIL 챌린지",
-                            null,
-                            "인강 듣기",
-                            "REJECT",
-                            "인강 진짜 열심히 들었습니다. ㅎ",
-                            "인강 달리는 짤.png",
-                            "우리 오늘 인강 듣는날 아닌데?"
-                    ),
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            3L,
-                            "두게더 개발단",
-                            null,
-                            "두게더 API 구현",
-                            "REJECT",
-                            "API 좀 잘 만든듯 ㅋ",
-                            "API 명세짤.png",
-                            "아 별론데?"
-                    )
-            );
-        }
-        else {
-            certifications = List.of(
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            1L,
-                            null,
-                            null,
-                            "운동 하기",
-                            "REVIEW_PENDING",
-                            "운동 개조짐 ㅋㅋㅋㅋ",
-                            "운동 조지는 짤.png",
-                            null
-                    ),
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            2L,
-                            null,
-                            null,
-                            "인강 듣기",
-                            "REVIEW_PENDING",
-                            "인강 진짜 열심히 들었습니다. ㅎ",
-                            "인강 달리는 짤.png",
-                            null
-                    ),
-                    new GetMemberAllStatsResponse.DailyTodoCertifications(
-                            3L,
-                            null,
-                            null,
-                            "두게더 API 구현",
-                            "REVIEW_PENDING",
-                            "API 좀 잘 만든듯 ㅋ",
-                            "API 명세짤.png",
-                            null
+                            List.of(
+                                    new GetMemberAllStatsResponse.DailyTodoCertificationInfo(
+                                            2L,
+                                            "인강 듣기",
+                                            "REJECT",
+                                            "인강 진짜 열심히 들었습니다. ㅎ",
+                                            "인강 달리는 짤.png",
+                                            "우리 오늘 인강 듣는날 아닌데?"
+                                    )
+                            )
                     )
             );
         }
 
-        GetMemberAllStatsResponse response = new GetMemberAllStatsResponse(stats, certifications);
+        GetMemberAllStatsResponse response = new GetMemberAllStatsResponse(stats, dailyTodoCertifications);
 
         return ResponseEntity.ok(ApiResponse.successWithData(GET_MEMBER_ALL_STATS, response));
     }

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetGroupActivityStatResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetGroupActivityStatResponse.java
@@ -3,12 +3,14 @@ package site.dogether.memberactivity.controller.response;
 import java.util.List;
 
 public record GetGroupActivityStatResponse(
-        String name,
-        String endAt,
+        ChallengeGroupInfoResponse groupInfo,
         List<CertificationPeriodResponse> certificationPeriods,
         RankingResponse ranking,
         MemberStatsResponse stats
         ) {
+
+        public record ChallengeGroupInfoResponse(String name, int maximumMemberCount, int currentMemberCount, String joinCode, String endAt) {
+        }
 
         public record CertificationPeriodResponse(int day, int createdCount, int certificatedCount, int certificationRate) {
         }

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetMemberAllStatsResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetMemberAllStatsResponse.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public record GetMemberAllStatsResponse(
         DailyTodoStats dailyTodoStats,
-        List<DailyTodoCertifications> dailyTodoCertifications
+        List<Object> dailyTodoCertifications
 ) {
 
     public record DailyTodoStats(
@@ -16,12 +16,20 @@ public record GetMemberAllStatsResponse(
     ) {
     }
 
-    public record DailyTodoCertifications(
-            Long id,
-            @JsonInclude(JsonInclude.Include.NON_NULL)
-            String groupName,
-            @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record CertificationsSortByTodoCompletedAt(
             String createdAt,
+            List<DailyTodoCertificationInfo> certificationInfo
+    ){
+    }
+
+    public record CertificationsSortByGroupCreatedAt(
+            String groupName,
+            List<DailyTodoCertificationInfo> certificationInfo
+    ){
+    }
+
+    public record DailyTodoCertificationInfo(
+            Long id,
             String content,
             String status,
             String certificationContent,

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetMemberAllStatsResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetMemberAllStatsResponse.java
@@ -18,6 +18,10 @@ public record GetMemberAllStatsResponse(
 
     public record DailyTodoCertifications(
             Long id,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            String groupName,
+            @JsonInclude(JsonInclude.Include.NON_NULL)
+            String createdAt,
             String content,
             String status,
             String certificationContent,

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -242,6 +242,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .rank(1)
                         .profileImageUrl("성욱이의 셀카.png")
                         .name("성욱")
+                        .historyReadStatus("NULL")
                         .achievementRate(100)
                         .build(),
 
@@ -250,6 +251,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .rank(2)
                         .profileImageUrl("고양이.png")
                         .name("영재")
+                        .historyReadStatus("READALL")
                         .achievementRate(80)
                         .build(),
 
@@ -258,6 +260,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .rank(3)
                         .profileImageUrl("그로밋.png")
                         .name("서은")
+                        .historyReadStatus("READYET")
                         .achievementRate(60)
                         .build()
         );
@@ -296,6 +299,9 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                             .type(JsonFieldType.STRING),
                     fieldWithPath("data.ranking[].name")
                         .description("그룹원 이름")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.ranking[].historyReadStatus")
+                        .description("히스토리 읽음 상태 {옵션: NULL, READYET, READALL}")
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.ranking[].achievementRate")
                         .description("데일리 투두 인증률")

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -43,10 +43,19 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("message")
                                         .description("응답 메시지")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.name")
+                                fieldWithPath("data.groupInfo.name")
                                         .description("그룹 이름")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.endAt")
+                                fieldWithPath("data.groupInfo.maximumMemberCount")
+                                        .description("그룹 참여 가능 인원수")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.groupInfo.currentMemberCount")
+                                        .description("현재 그룹 인원수")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.groupInfo.joinCode")
+                                        .description("초대 코드")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.groupInfo.endAt")
                                         .description("종료일")
                                         .type(JsonFieldType.STRING),
                                 fieldWithPath("data.certificationPeriods")

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -10,8 +10,7 @@ import site.dogether.memberactivity.controller.MemberActivityController;
 
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 class MemberActivityControllerDocsTest extends RestDocsSupport {
@@ -91,16 +90,24 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         .type(JsonFieldType.NUMBER))));
     }
 
-    @DisplayName("사용자의 활동 통계 및 작성한 인증 목록 전체 조회 API")
+    @DisplayName("사용자의 활동 통계 및 작성한 인증 목록 전체 조회 API (투두 완료일 순)")
     @Test
-    void getMemberAllStats() throws Exception {
+    void getMemberAllStatsSortedByTodoCompletedAt() throws Exception {
 
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/my/activity")
+                                .param("sort", "todo-completed-at")
+                                .param("status", "approve")
                                 .header("Authorization", "Bearer access_token")
                                 .contentType(MediaType.APPLICATION_JSON_VALUE))
                 .andExpect(status().isOk())
                 .andDo(createDocument(
+                        queryParameters(
+                                parameterWithName("sort")
+                                        .description("정렬 방식 {옵션 : todo-completed-at, group-created-at}"),
+                                parameterWithName("status")
+                                        .optional()
+                                        .description("데일리 투두 상태 {옵션: approve, reject, review_pending}")),
                         responseFields(
                                 fieldWithPath("code")
                                         .description("응답 코드")
@@ -124,6 +131,13 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.dailyTodoCertifications[].id")
                                         .description("데일리 투두 id")
                                         .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.dailyTodoCertifications[].groupName")
+                                        .description("챌린지 그룹명")
+                                        .optional()
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].createdAt")
+                                        .description("데일리 투두 인증 날짜")
+                                        .type(JsonFieldType.STRING),
                                 fieldWithPath("data.dailyTodoCertifications[].content")
                                         .description("데일리 투두 내용")
                                         .type(JsonFieldType.STRING),
@@ -139,7 +153,72 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.dailyTodoCertifications[]rejectReason")
                                         .description("데일리 투두 인증 노인정 사유")
                                         .optional()
-                                        .type(JsonFieldType.STRING)
-                        )));
+                                        .type(JsonFieldType.STRING))));
+    }
+
+    @DisplayName("사용자의 활동 통계 및 작성한 인증 목록 전체 조회 API (그룹 생성일 순)")
+    @Test
+    void getMemberAllStatsSortedByGroupCreatedAt() throws Exception {
+
+        mockMvc.perform(
+                        MockMvcRequestBuilders.get("/api/my/activity")
+                                .param("sort", "group-created-at")
+                                .param("status", "reject")
+                                .header("Authorization", "Bearer access_token")
+                                .contentType(MediaType.APPLICATION_JSON_VALUE))
+                .andExpect(status().isOk())
+                .andDo(createDocument(
+                        queryParameters(
+                                parameterWithName("sort")
+                                        .description("정렬 방식 {옵션 : todo-completed-at, group-created-at}"),
+                                parameterWithName("status")
+                                        .optional()
+                                        .description("데일리 투두 상태 {옵션: approve, reject, review_pending}")),
+                        responseFields(
+                                fieldWithPath("code")
+                                        .description("응답 코드")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("message")
+                                        .description("응답 메시지")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoStats.totalCertificatedCount")
+                                        .description("사용자의 인증 목록 개수")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.dailyTodoStats.totalApprovedCount")
+                                        .description("사용자의 인정받은 투두 개수")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.dailyTodoStats.totalRejectedCount")
+                                        .description("사용자의 노인정 받은 투두 개수")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.dailyTodoCertifications")
+                                        .description("개인 인증 목록 전체 조회")
+                                        .optional()
+                                        .type(JsonFieldType.ARRAY),
+                                fieldWithPath("data.dailyTodoCertifications[].id")
+                                        .description("데일리 투두 id")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.dailyTodoCertifications[].groupName")
+                                        .description("챌린지 그룹명")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].createdAt")
+                                        .description("데일리 투두 인증 날짜")
+                                        .optional()
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].content")
+                                        .description("데일리 투두 내용")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].status")
+                                        .description("데일리 투두 상태")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].certificationContent")
+                                        .description("데일리 투두 인증글 내용")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].certificationMediaUrl")
+                                        .description("데일리 투두 인증글 이미지 URL")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[]rejectReason")
+                                        .description("데일리 투두 인증 노인정 사유")
+                                        .optional()
+                                        .type(JsonFieldType.STRING))));
     }
 }

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -125,32 +125,31 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         .description("사용자의 노인정 받은 투두 개수")
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.dailyTodoCertifications")
-                                        .description("개인 인증 목록 전체 조회")
+                                        .description("인증한 투두 목록")
                                         .optional()
                                         .type(JsonFieldType.ARRAY),
-                                fieldWithPath("data.dailyTodoCertifications[].id")
+                                fieldWithPath("data.dailyTodoCertifications[].createdAt")
+                                        .description("투두 완료일")
+                                        .type(JsonFieldType.STRING),
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo")
+                                        .description("투두 인증 정보")
+                                        .type(JsonFieldType.ARRAY),
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].id")
                                         .description("데일리 투두 id")
                                         .type(JsonFieldType.NUMBER),
-                                fieldWithPath("data.dailyTodoCertifications[].groupName")
-                                        .description("챌린지 그룹명")
-                                        .optional()
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].createdAt")
-                                        .description("데일리 투두 인증 날짜")
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].content")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].content")
                                         .description("데일리 투두 내용")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].status")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].status")
                                         .description("데일리 투두 상태")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].certificationContent")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].certificationContent")
                                         .description("데일리 투두 인증글 내용")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].certificationMediaUrl")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].certificationMediaUrl")
                                         .description("데일리 투두 인증글 이미지 URL")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[]rejectReason")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].rejectReason")
                                         .description("데일리 투두 인증 노인정 사유")
                                         .optional()
                                         .type(JsonFieldType.STRING))));
@@ -191,32 +190,31 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         .description("사용자의 노인정 받은 투두 개수")
                                         .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.dailyTodoCertifications")
-                                        .description("개인 인증 목록 전체 조회")
+                                        .description("인증한 투두 목록")
                                         .optional()
                                         .type(JsonFieldType.ARRAY),
-                                fieldWithPath("data.dailyTodoCertifications[].id")
-                                        .description("데일리 투두 id")
-                                        .type(JsonFieldType.NUMBER),
                                 fieldWithPath("data.dailyTodoCertifications[].groupName")
                                         .description("챌린지 그룹명")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].createdAt")
-                                        .description("데일리 투두 인증 날짜")
-                                        .optional()
-                                        .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].content")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo")
+                                        .description("투두 인증 정보")
+                                        .type(JsonFieldType.ARRAY),
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].id")
+                                        .description("데일리 투두 id")
+                                        .type(JsonFieldType.NUMBER),
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].content")
                                         .description("데일리 투두 내용")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].status")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].status")
                                         .description("데일리 투두 상태")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].certificationContent")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].certificationContent")
                                         .description("데일리 투두 인증글 내용")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[].certificationMediaUrl")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].certificationMediaUrl")
                                         .description("데일리 투두 인증글 이미지 URL")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.dailyTodoCertifications[]rejectReason")
+                                fieldWithPath("data.dailyTodoCertifications[].certificationInfo[].rejectReason")
                                         .description("데일리 투두 인증 노인정 사유")
                                         .optional()
                                         .type(JsonFieldType.STRING))));


### PR DESCRIPTION
### 수정된 api
- 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 api
- 참여중인 특정 챌린지 그룹 활동 통계 조회 api
- 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 api

클라이언트의 요구사항에 맞춰 문서 수정하였습니다.

### 수정 사항
- 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 api
    - member Id값 추가
    - 스토리 존재하는지 상태 여부 추가
- 참여중인 특정 챌린지 그룹 활동 통계 조회 api
    - 초대코드 추가
    - 그룹원 수(최대 그룹 참여 인원, 현재 참여중인 인원) 추가
- 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 api
    - 필터링 추가(투두 완료일 순, 그룹 생성일 순)
    - 검사 대기, 인정, 노인정 필터링 추가

This closes #55