### PR TITLE
[BE] 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 api 구현

### DIFF
--- a/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
+++ b/src/main/java/site/dogether/memberactivity/controller/MemberActivityController.java
@@ -48,7 +48,7 @@ public class MemberActivityController {
 
         List<Object> dailyTodoCertifications = null;
 
-        if(sort.equals("todo-completed-at")) {
+        if(sort.equals("TODO_COMPLETED_AT")) {
             dailyTodoCertifications = List.of(
                     new GetMemberAllStatsResponse.CertificationsSortByTodoCompletedAt(
                             "2025.05.01",
@@ -78,7 +78,7 @@ public class MemberActivityController {
                     )
             );
         }
-        else if (sort.equals("group-created-at")) {
+        else if (sort.equals("GROUP_CREATED_AT")) {
             dailyTodoCertifications = List.of(
                     new GetMemberAllStatsResponse.CertificationsSortByGroupCreatedAt(
                             "스쿼트 챌린지",


### PR DESCRIPTION
### 문제 사항
쿼리 파라미터 값들이 대문자로 들어가면서 기존에 소문자로 작성되었던 더미 데이터들이 null 값으로 들어가는 문제가 발생하였습니다.

### 수정 사항
해당 부분의 문제를 해결하기 위해 쿼리 파라미터 값을 통해 더미 데이터가 제대로 들어갈 수 있도록 대문자로 수정하였습니다.

PR을 올리기에는 코드 변경 사항이 적으나 해당 문제로 인해 RestDocs 문서에서 null 값을 보여주어 제대로 된 데이터 형식을 보여주지 않고 있기에, 클라이언트가 문서를 통해 작업을 수월하게 할 수  있도록 해당 부분만 먼저 PR 올렸습니다.