### PR TITLE
[BE] 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 API 수정

### DIFF
--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -83,9 +83,10 @@ public class ChallengeGroupController {
 
     @GetMapping("/{groupId}/ranking")
     public ResponseEntity<ApiResponse<GetChallengeGroupMembersRank>> getJoiningChallengeGroupTeamRanking(
+            @Authenticated final Long memberId,
             @PathVariable final Long groupId
     ) {
-        List<ChallengeGroupMemberRankResponse> groupMemberRanks = challengeGroupService.getChallengeGroupRanking(groupId);
+        List<ChallengeGroupMemberRankResponse> groupMemberRanks = challengeGroupService.getChallengeGroupRanking(memberId, groupId);
 
         GetChallengeGroupMembersRank response = new GetChallengeGroupMembersRank(groupMemberRanks);
 

--- a/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistoryReadStatus.java
+++ b/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistoryReadStatus.java
@@ -1,0 +1,16 @@
+package site.dogether.dailytodohistory.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DailyTodoHistoryReadStatus {
+
+    NULL("history 존재하지 않음"),
+    READ_ALL("history 전부 읽음"),
+    READ_YET("읽어야 할 history 존재"),
+    ;
+
+    private final String description;
+}

--- a/src/main/java/site/dogether/dailytodohistory/exception/InvalidDailyTodoHistoryReadStatusException.java
+++ b/src/main/java/site/dogether/dailytodohistory/exception/InvalidDailyTodoHistoryReadStatusException.java
@@ -1,0 +1,8 @@
+package site.dogether.dailytodohistory.exception;
+
+public class InvalidDailyTodoHistoryReadStatusException extends RuntimeException
+{
+    public InvalidDailyTodoHistoryReadStatusException(final String message) {
+        super(message);
+    }
+}

--- a/src/main/java/site/dogether/dailytodohistory/service/DailyTodoHistoryService.java
+++ b/src/main/java/site/dogether/dailytodohistory/service/DailyTodoHistoryService.java
@@ -10,6 +10,7 @@ import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodohistory.entity.DailyTodoHistory;
 import site.dogether.dailytodohistory.entity.DailyTodoHistoryRead;
+import site.dogether.dailytodohistory.entity.DailyTodoHistoryReadStatus;
 import site.dogether.dailytodohistory.exception.DailyTodoHistoryAlreadyReadException;
 import site.dogether.dailytodohistory.exception.DailyTodoHistoryNotFoundException;
 import site.dogether.dailytodohistory.repository.DailyTodoHistoryReadRepository;
@@ -143,17 +144,23 @@ public class DailyTodoHistoryService {
         }
     }
 
-    /**
-     * viewer -> 랭킹 페이지를 조회한 요청자
-     * viewer 입장에서 특정 챌린지 그룹에 속한 특정 사용자의 오늘 투두 히스토리 중 읽지 않은 히스토리가 존재하면 true 반환, 없으면(다 읽었으면) false
-     */
-    public boolean hasNotReadTodayDailyTodoHistory(
+    public DailyTodoHistoryReadStatus getTodayDailyTodoHistoryReadStatus(
         final Member viewer,
         final ChallengeGroup challengeGroup,
         final Member targetMember
     ) {
         final List<DailyTodoHistory> dailyTodoHistories = findAllTodayDailyTodoHistoryByChallengeGroupAndTargetMember(challengeGroup, targetMember);
-        return dailyTodoHistories.stream()
-            .anyMatch(dailyTodoHistory -> !checkMemberReadDailyTodoHistory(viewer, dailyTodoHistory));
+
+        if (dailyTodoHistories.isEmpty()) {
+            return DailyTodoHistoryReadStatus.NULL;
+        }
+
+        for (DailyTodoHistory dailyTodoHistory : dailyTodoHistories) {
+            if (!checkMemberReadDailyTodoHistory(viewer, dailyTodoHistory)) {
+                return DailyTodoHistoryReadStatus.READ_YET;
+            }
+        }
+
+        return DailyTodoHistoryReadStatus.READ_ALL;
     }
 }

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -1,23 +1,5 @@
 package site.dogether.docs.challengegroup;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_DURATION_OPTION;
-import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_START_AT_OPTION;
-import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_STATUS;
-import static site.dogether.docs.util.DocumentLinkGenerator.generateLink;
-
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -30,6 +12,19 @@ import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 import site.dogether.docs.util.RestDocsSupport;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.*;
+import static site.dogether.docs.util.DocumentLinkGenerator.generateLink;
 
 @DisplayName("챌린지 그룹 API 문서화 테스트")
 public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
@@ -246,8 +241,6 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     @DisplayName("참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 API")
     @Test
     void getJoiningChallengeGroupTeamActivitySummary() throws Exception {
-        final long groupId = 1L;
-
         final List<ChallengeGroupMemberRankResponse> groupMemberRanks = List.of(
                 ChallengeGroupMemberRankResponse.builder()
                         .memberId(1L)
@@ -263,7 +256,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .rank(2)
                         .profileImageUrl("고양이.png")
                         .name("영재")
-                        .historyReadStatus("READALL")
+                        .historyReadStatus("READ_ALL")
                         .achievementRate(80)
                         .build(),
 
@@ -272,16 +265,16 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .rank(3)
                         .profileImageUrl("그로밋.png")
                         .name("서은")
-                        .historyReadStatus("READYET")
+                        .historyReadStatus("READ_YET")
                         .achievementRate(60)
                         .build()
         );
 
-        given(challengeGroupService.getChallengeGroupRanking(groupId))
+        given(challengeGroupService.getChallengeGroupRanking(any(), any()))
                 .willReturn(groupMemberRanks);
 
         mockMvc.perform(
-                get("/api/groups/{groupId}/ranking", groupId)
+                get("/api/groups/{groupId}/ranking", 1)
                     .header("Authorization", "Bearer access_token")
                     .contentType(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
@@ -289,7 +282,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                 pathParameters(
                     parameterWithName("groupId")
                         .description("챌린지 그룹 id")
-                            .attributes(constraints("존재하는 챌린지 그룹 id만 입력 가능"), pathVariableExample(groupId))),
+                            .attributes(constraints("존재하는 챌린지 그룹 id만 입력 가능"), pathVariableExample(1))),
                 responseFields(
                     fieldWithPath("code")
                         .description("응답 코드")

--- a/src/test/java/site/dogether/docs/util/EnumDocs.java
+++ b/src/test/java/site/dogether/docs/util/EnumDocs.java
@@ -1,10 +1,11 @@
 package site.dogether.docs.util;
 
-import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Map;
 
 @Getter
 @NoArgsConstructor


### PR DESCRIPTION
### 수정사항
- 각 멤버별 히스토리 읽을 것이 남았는지 상태 포함

### 상세 설명
viewer 기준으로 랭킹을 조회하였을 때 같은 챌린지 그룹에 존재하는 멤버들의 히스토리를 읽었는지 안읽었는지 여부를 표시하도록 상태를 추가하였습니다.

This closes #43