### PR TITLE
[BE] 챌린지 그룹 진행일, 진행률 증가 기준 수정

### DIFF
--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -152,26 +152,24 @@ public class ChallengeGroup extends BaseEntity {
         if (isReady()) {
             return 0;
         }
-        if (isRunning()) {
-            return (int) ChronoUnit.DAYS.between(startAt, today) + 1;
-        }
         if (isFinished()) {
-            return (int) ChronoUnit.DAYS.between(startAt, endAt);
+            return (int) ChronoUnit.DAYS.between(startAt, endAt) + 1;
         }
         return (int) ChronoUnit.DAYS.between(startAt, today) + 1;
     }
 
     public double getProgressRate() {
         int progressDay = getProgressDay();
-        int duration = getDuration();
+        int duration = getDurationWithDDay();
         if (progressDay > duration) {
             return 1;
         }
-        return (double) progressDay / duration;
+        double rawRate = (double) progressDay / duration;
+        return Math.round(rawRate * 100) / 100.0;
     }
 
-    private int getDuration() {
-        return (int) ChronoUnit.DAYS.between(startAt, endAt);
+    private int getDurationWithDDay() {
+        return (int) ChronoUnit.DAYS.between(startAt, endAt) + 1;
     }
 
     public void updateStatus() {

--- a/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
@@ -115,7 +115,7 @@ class ChallengeGroupTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6})
+    @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7})
     void 챌린지_그룹의_진행일을_계산한다__RUNNING이면_하루씩_증가한다(final int daysSinceStart) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
         final ChallengeGroup challengeGroup = new ChallengeGroup(
@@ -134,22 +134,23 @@ class ChallengeGroupTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {7, 8, 9})
+    @ValueSource(ints = {8, 9})
     void 챌린지_그룹의_진행일을_계산한다__FINISHED(final int daysSinceStart) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
+        int duration = 7;
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
                 10,
                 startAt,
-                startAt.plusDays(7),
+                startAt.plusDays(duration),
                 "join_code",
                 ChallengeGroupStatus.FINISHED
         );
 
         final int progressDay = challengeGroup.getProgressDay();
 
-        assertThat(progressDay).isEqualTo(7);
+        assertThat(progressDay).isEqualTo(duration + 1);
     }
 
     @Test
@@ -172,15 +173,16 @@ class ChallengeGroupTest {
 
     @ParameterizedTest
     @CsvSource({
-            "0, 0.14285714285714285",
-            "1, 0.2857142857142857",
-            "2, 0.42857142857142855",
-            "3, 0.5714285714285714",
-            "4, 0.7142857142857143",
-            "5, 0.8571428571428571",
-            "6, 1.0"
+            "0, 0.13",
+            "1, 0.25",
+            "2, 0.38",
+            "3, 0.5",
+            "4, 0.63",
+            "5, 0.75",
+            "6, 0.88",
+            "7, 1.0"
     })
-    void 챌린지_그룹의_진행률을_계산한다__RUNNING이면_진행일_나누기_기간(final int daysSinceStart, final double expected) {
+    void 챌린지_그룹의_진행률을_계산한다__RUNNING이면_진행일_나누기_종료일_포함한_기간(final int daysSinceStart, final double expected) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
@@ -198,7 +200,7 @@ class ChallengeGroupTest {
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {7, 8, 9})
+    @ValueSource(ints = {8, 9})
     void 챌린지_그룹의_진행률을_계산한다__FINISHED이면_1이다(final int daysSinceStart) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
         final ChallengeGroup challengeGroup = new ChallengeGroup(


### PR DESCRIPTION
### 변경 사항

**수정 전 : 마지막 수행일까지 증가**

예시) 5월 9일에 만든 3일짜리 오늘 시작 그룹인 경우

5.10일에 조회 - progressDay 2
5.11일(마지막 활동일)에 조회 → progressDay 3
5.12일(dday)에 조회 → progressDay 3
5.13일에 조회 → progressDay 3

**수정 후: 종료일(D_DAY)까지 증가**

5.10일에 조회 - progressDay 2
5.11일(마지막 활동일)에 조회 → progressDay 3
5.12일(dday)에 조회 → progressDay 4
5.13일에 조회 → progressDay 4