### PR TITLE
[BE] 챌린지 그룹 참여 코드 포멧 변경

### DIFF
--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -13,10 +13,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
-import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +34,7 @@ public class ChallengeGroup extends BaseEntity {
     private static final int MAXIMUM_GROUP_NAME_LENGTH = 10;
     private static final int MIN_MAXIMUM_MEMBER_COUNT = 2;
     private static final int MAX_MAXIMUM_MEMBER_COUNT = 20;
+    private static final int JOIN_CODE_LENGTH = 8;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -107,7 +108,15 @@ public class ChallengeGroup extends BaseEntity {
     }
 
     private static String generateJoinCode() {
-        return UUID.randomUUID().toString().substring(0, 6);
+        String charSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+        SecureRandom random = new SecureRandom();
+        StringBuilder codeBuilder = new StringBuilder(JOIN_CODE_LENGTH);
+
+        for (int i = 0; i < JOIN_CODE_LENGTH; i++) {
+            int index = random.nextInt(charSet.length());
+            codeBuilder.append(charSet.charAt(index));
+        }
+        return codeBuilder.toString();
     }
 
     private static ChallengeGroupStatus initStatus(final LocalDate startAt) {


### PR DESCRIPTION
### 변경 사항

- 변경 이유: 참여 코드 정책이 문자 포함으로 변경됨에 따라, 기존 UUID 기반 6자리 방식에서 SecureRandom 기반 8자리 영문+숫자 조합으로 생성 방식 변경
- 수정 전: UUID를 이용한 6자리 랜덤 난수 생성
- 수정 후: SecureRandom 난수를 활용해 8자리(숫자+알파벳 대/소 문자) 코드 생성
