### PR TITLE
[BE] 챌린지 그룹 참여 여부 조회 API 추가

### DIFF
--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -45,6 +45,28 @@ include::{snippets}/challenge-group-controller-docs-test/join-challenge-group/re
 include::{snippets}/challenge-group-controller-docs-test/join-challenge-group/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/join-challenge-group/response-fields.adoc[]
 
+[[is-participating-challenge-group]]
+=== 챌린지 그룹 참여 여부 조회
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| O
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/challenge-group-controller-docs-test/is-participating-challenge-group/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/challenge-group-controller-docs-test/is-participating-challenge-group/http-response.adoc[]
+include::{snippets}/challenge-group-controller-docs-test/is-participating-challenge-group/response-fields.adoc[]
+
+
 [[get-joining-challenge-groups]]
 === 참여중인 챌린지 그룹 정보 전체 조회
 
@@ -65,6 +87,8 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 ==== HTTP Response
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/response-fields.adoc[]
+
+[[get-challenge-group]]
 
 [[get-joining-challenge-group-team-activity-summary]]
 === 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -1,5 +1,13 @@
 package site.dogether.challengegroup.controller;
 
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.CREATE_CHALLENGE_GROUP;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.GET_JOINING_CHALLENGE_GROUPS;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.IS_PARTICIPATING_CHALLENGE_GROUP;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.JOIN_CHALLENGE_GROUP;
+import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.LEAVE_CHALLENGE_GROUP;
+import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_GROUP_ACTIVITY_STAT;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -16,16 +24,12 @@ import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRank
 import site.dogether.challengegroup.controller.response.CreateChallengeGroupResponse;
 import site.dogether.challengegroup.controller.response.GetChallengeGroupMembersRank;
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupsResponse;
+import site.dogether.challengegroup.controller.response.IsParticipatingChallengeGroupResponse;
 import site.dogether.challengegroup.controller.response.JoinChallengeGroupResponse;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 import site.dogether.common.controller.response.ApiResponse;
-
-import java.util.List;
-
-import static site.dogether.challengegroup.controller.response.ChallengeGroupSuccessCode.*;
-import static site.dogether.memberactivity.controller.response.MemberActivitySuccessCode.GET_GROUP_ACTIVITY_STAT;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/groups")
@@ -78,6 +82,18 @@ public class ChallengeGroupController {
         challengeGroupService.leaveChallengeGroup(memberId, groupId);
         return ResponseEntity.ok(ApiResponse.success(
                 LEAVE_CHALLENGE_GROUP
+        ));
+    }
+
+    @GetMapping("/participating")
+    public ResponseEntity<ApiResponse<IsParticipatingChallengeGroupResponse>> isParticipatingChallengeGroup(
+            @Authenticated final Long memberId
+    ) {
+        IsParticipatingChallengeGroupResponse response
+                = challengeGroupService.isParticipatingChallengeGroup(memberId);
+        return ResponseEntity.ok(ApiResponse.successWithData(
+                IS_PARTICIPATING_CHALLENGE_GROUP,
+                response
         ));
     }
 

--- a/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
@@ -12,7 +12,7 @@ public enum ChallengeGroupSuccessCode implements SuccessCode {
     JOIN_CHALLENGE_GROUP("CGS-0002", "챌린지 그룹에 참여하였습니다."),
     GET_JOINING_CHALLENGE_GROUPS("CGS-0003", "참여중인 챌린지 그룹 정보를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_NAMES("CGS-0004", "참여중인 챌린지 그룹 목록을 조회하였습니다."),
-    HAS_CHALLENGE_GROUP("CGS-0005", "챌린지 그룹 참여 여부를 조회하였습니다."),
+    IS_PARTICIPATING_CHALLENGE_GROUP("CGS-0005", "챌린지 그룹 참여 여부를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY("CGS-0007", "참여중인 그룹의 팀 전체 누적 활동 통계 정보를 조회하였습니다."),
     LEAVE_CHALLENGE_GROUP("CGS-0008", "챌린지 그룹을 탈퇴하였습니다."),
     ;

--- a/src/main/java/site/dogether/challengegroup/controller/response/IsParticipatingChallengeGroupResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/IsParticipatingChallengeGroupResponse.java
@@ -1,0 +1,4 @@
+package site.dogether.challengegroup.controller.response;
+
+public record IsParticipatingChallengeGroupResponse(boolean isParticipating) {
+}

--- a/src/main/java/site/dogether/challengegroup/controller/response/JoinChallengeGroupResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/JoinChallengeGroupResponse.java
@@ -4,6 +4,7 @@ import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 
 public record JoinChallengeGroupResponse(
     String groupName,
+    int duration,
     int maximumMemberCount,
     String startAt,
     String endAt
@@ -11,6 +12,7 @@ public record JoinChallengeGroupResponse(
     public static JoinChallengeGroupResponse from(JoinChallengeGroupDto joinChallengeGroupDto) {
         return new JoinChallengeGroupResponse(
             joinChallengeGroupDto.groupName(),
+            joinChallengeGroupDto.duration(),
             joinChallengeGroupDto.maximumMemberCount(),
             joinChallengeGroupDto.startAt(),
             joinChallengeGroupDto.endAt()

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -181,6 +181,10 @@ public class ChallengeGroup extends BaseEntity {
         return (int) ChronoUnit.DAYS.between(startAt, endAt) + 1;
     }
 
+    public int getDuration() {
+        return (int) ChronoUnit.DAYS.between(startAt, endAt);
+    }
+
     public void updateStatus() {
         LocalDate now = LocalDate.now();
         if (status == READY && isStart(now)) {

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.controller.request.CreateChallengeGroupRequest;
 import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRankResponse;
+import site.dogether.challengegroup.controller.response.IsParticipatingChallengeGroupResponse;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupMember;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
@@ -166,6 +167,16 @@ public class ChallengeGroupService {
             throw new FinishedChallengeGroupException(
                     String.format("이미 종료된 그룹입니다. (groupId: %d)", joiningGroup.getId()));
         }
+    }
+
+    public IsParticipatingChallengeGroupResponse isParticipatingChallengeGroup(Long memberId) {
+        final Member member = memberService.getMember(memberId);
+        final List<ChallengeGroupMember> challengeGroupMembers = challengeGroupMemberRepository.findNotFinishedGroupByMember(member);
+
+        if (challengeGroupMembers.isEmpty()) {
+            return new IsParticipatingChallengeGroupResponse(false);
+        }
+        return new IsParticipatingChallengeGroupResponse(true);
     }
 
     public List<ChallengeGroupMemberRankResponse> getChallengeGroupRanking(final Long memberId, final Long groupId) {

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoinChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoinChallengeGroupDto.java
@@ -5,6 +5,7 @@ import site.dogether.challengegroup.entity.ChallengeGroup;
 
 public record JoinChallengeGroupDto(
         String groupName,
+        int duration,
         int maximumMemberCount,
         String startAt,
         String endAt
@@ -16,6 +17,7 @@ public record JoinChallengeGroupDto(
 
         return new JoinChallengeGroupDto(
                 challengeGroup.getName(),
+                challengeGroup.getDuration(),
                 challengeGroup.getMaximumMemberCount(),
                 startAtFormatted,
                 endAtFormatted

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -1,5 +1,23 @@
 package site.dogether.docs.challengegroup;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_DURATION_OPTION;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_START_AT_OPTION;
+import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.CHALLENGE_GROUP_STATUS;
+import static site.dogether.docs.util.DocumentLinkGenerator.generateLink;
+
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -12,19 +30,6 @@ import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 import site.dogether.docs.util.RestDocsSupport;
-
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static site.dogether.docs.util.DocumentLinkGenerator.DocUrl.*;
-import static site.dogether.docs.util.DocumentLinkGenerator.generateLink;
 
 @DisplayName("챌린지 그룹 API 문서화 테스트")
 public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
@@ -41,7 +46,7 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
     void createChallengeGroup() throws Exception {
         final CreateChallengeGroupRequest request = new CreateChallengeGroupRequest(
             "성욱이와 친구들",
-            8,
+            10,
             "TOMORROW",
             3
         );
@@ -94,7 +99,8 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
         given(challengeGroupService.joinChallengeGroup(any(), any()))
             .willReturn(new JoinChallengeGroupDto(
                     "성욱이와 친구들",
-                    8,
+                    3,
+                    10,
                     "25.03.02",
                     "25.03.05"
             ));
@@ -121,6 +127,9 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("data.groupName")
                         .description("그룹명")
                         .type(JsonFieldType.STRING),
+                    fieldWithPath("data.duration")
+                        .description("총 기간")
+                        .type(JsonFieldType.NUMBER),
                     fieldWithPath("data.maximumMemberCount")
                         .description("총 인원수")
                         .type(JsonFieldType.NUMBER),

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -26,6 +26,7 @@ import site.dogether.challengegroup.controller.ChallengeGroupController;
 import site.dogether.challengegroup.controller.request.CreateChallengeGroupRequest;
 import site.dogether.challengegroup.controller.request.JoinChallengeGroupRequest;
 import site.dogether.challengegroup.controller.response.ChallengeGroupMemberRankResponse;
+import site.dogether.challengegroup.controller.response.IsParticipatingChallengeGroupResponse;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
@@ -245,6 +246,30 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         fieldWithPath("message")
                             .description("응답 메시지")
                             .type(JsonFieldType.STRING))));
+    }
+
+    @DisplayName("챌린지 그룹 참여 여부 조회 API")
+    @Test
+    void isParticipatingChallengeGroup() throws Exception {
+        given(challengeGroupService.isParticipatingChallengeGroup(any()))
+            .willReturn(new IsParticipatingChallengeGroupResponse(true));
+
+        mockMvc.perform(
+                get("/api/groups/participating")
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.isParticipating")
+                        .description("참여 여부")
+                        .type(JsonFieldType.BOOLEAN))));
     }
 
     @DisplayName("참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회 API")


### PR DESCRIPTION
### 주요 변경 사항
- 챌린지 그룹 참여 여부 조회 API를 추가합니다.

수정 전: 특정 페이지 분기를 위해 참여 여부만 필요한 상황인데 기존엔 전체 그룹 리스트 조회해서 참여 여부 판단함
수정 후: 챌린지 그룹 참여 여부 조회 API를 추가


추가 변경 사항
- 챌린지 그룹 참여 API 응답 필드에 duration 추가