### PR TITLE
[BE] 잘못 설정된 사용자 프로필 이미지 URL 정정

### DIFF
--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -63,21 +63,21 @@ public class Member extends BaseEntity {
 
     private static String saveRandomProfileImageUrl() {
         List<String> profileImageUrls = List.of(
-                "s3://dogether-bucket-dev/member_profile_image/blue_1",
-                "s3://dogether-bucket-dev/member_profile_image/blue_2",
-                "s3://dogether-bucket-dev/member_profile_image/blue_3",
-                "s3://dogether-bucket-dev/member_profile_image/blue_4",
-                "s3://dogether-bucket-dev/member_profile_image/blue_5",
-                "s3://dogether-bucket-dev/member_profile_image/red_1",
-                "s3://dogether-bucket-dev/member_profile_image/red_2",
-                "s3://dogether-bucket-dev/member_profile_image/red_3",
-                "s3://dogether-bucket-dev/member_profile_image/red_4",
-                "s3://dogether-bucket-dev/member_profile_image/red_5",
-                "s3://dogether-bucket-dev/member_profile_image/yellow_1",
-                "s3://dogether-bucket-dev/member_profile_image/yellow_2",
-                "s3://dogether-bucket-dev/member_profile_image/yellow_3",
-                "s3://dogether-bucket-dev/member_profile_image/yellow_4",
-                "s3://dogether-bucket-dev/member_profile_image/yellow_5"
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/blue_1.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/blue_2.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/blue_3.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/blue_4.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/blue_5.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/red_1.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/red_2.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/red_3.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/red_4.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/red_5.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/yellow_1.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/yellow_2.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/yellow_3.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/yellow_4.png",
+                "https://dogether-bucket-dev.s3.ap-northeast-2.amazonaws.com/member_profile_image/yellow_5.png"
         );
 
         return profileImageUrls.get((int) (Math.random() * profileImageUrls.size()));


### PR DESCRIPTION
잘못 설정된 사용자 프로필 이미지 설정을 정정하였습니다.
- S3 이미지 정리
- Member 도메인에 올바른 회원 프로필 이미지로 수정
- 기존 개발 서버 DB에 저장된 회원 이미지 정보를 올바른 이미지로 수동 변경

 This closes #84 