### PR TITLE
[BE] 투두 상태 변경 시 사용자 별 데일리 투두 통계 값 변경 기능 추가

### DIFF
--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -242,12 +242,6 @@ public class ChallengeGroupService {
         throw new MemberRankNotFoundException("해당 memberId에 대한 랭킹 정보를 찾을 수 없습니다.");
     }
 
-    private List<String> getChallengeGroupMemberProfileImages(final List<Member> groupMembers) {
-        return groupMembers.stream()
-                .map(Member::getProfileImageUrl)
-                .toList();
-    }
-
     public List<ChallengeGroupMemberRankInfoDto> getChallengeGroupMembersInfo(final List<ChallengeGroupMember> groupMembers, final ChallengeGroup challengeGroup) {
         return groupMembers.stream()
                 .map(member -> getChallengeGroupMemberInfo(member, challengeGroup))

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -25,6 +25,7 @@ import site.dogether.dailytodo.exception.NotReviewPendingDailyTodoException;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodocertification.exception.NotDailyTodoCertificationReviewerException;
 import site.dogether.member.entity.Member;
+import site.dogether.memberactivity.entity.DailyTodoStats;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -163,6 +164,7 @@ public class DailyTodo extends BaseEntity {
         return member.equals(target);
     }
 
+    // TODO: 투두 인증 시 certificated_count 값 증가 추가
     public DailyTodoCertification certify(
         final Member writer,
         final Member reviewer,
@@ -198,12 +200,14 @@ public class DailyTodo extends BaseEntity {
         }
     }
 
+    // TODO: 투두 리뷰 시 certificated_count 값 감소, approved_count or rejected_count 증가 추가
     public void review(
-        final Member reviewer,
-        final DailyTodoCertification dailyTodoCertification,
-        final DailyTodoStatus reviewResult,
-        final String rejectReason
-    ) {
+            final Member reviewer,
+            final DailyTodoCertification dailyTodoCertification,
+            final DailyTodoStatus reviewResult,
+            final String rejectReason,
+            final DailyTodoStats dailyTodoStats
+            ) {
         validateReviewer(reviewer, dailyTodoCertification);
         validateStatusIsReviewPending();
         validateReviewResult(reviewResult);
@@ -211,6 +215,8 @@ public class DailyTodo extends BaseEntity {
 
         this.status = reviewResult;
         this.rejectReason = rejectReason;
+
+        dailyTodoStats.moveCertificatedToResult(reviewResult);
     }
 
     private void validateReviewer(final Member reviewer, final DailyTodoCertification dailyTodoCertification) {

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -164,12 +164,12 @@ public class DailyTodo extends BaseEntity {
         return member.equals(target);
     }
 
-    // TODO: 투두 인증 시 certificated_count 값 증가 추가
     public DailyTodoCertification certify(
         final Member writer,
         final Member reviewer,
         final String certifyContent,
-        final String certifyMediaUrl
+        final String certifyMediaUrl,
+        final DailyTodoStats dailyTodoStats
     ) {
         validateWriter(writer);
         validateStatusIsCertifyPending();
@@ -177,6 +177,8 @@ public class DailyTodo extends BaseEntity {
 
         final DailyTodoCertification dailyTodoCertification = new DailyTodoCertification(this, reviewer, certifyContent, certifyMediaUrl);
         status = REVIEW_PENDING;
+
+        dailyTodoStats.increaseCertificatedCount();
 
         return dailyTodoCertification;
     }
@@ -200,7 +202,6 @@ public class DailyTodo extends BaseEntity {
         }
     }
 
-    // TODO: 투두 리뷰 시 certificated_count 값 감소, approved_count or rejected_count 증가 추가
     public void review(
             final Member reviewer,
             final DailyTodoCertification dailyTodoCertification,

--- a/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
+++ b/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
@@ -24,6 +24,9 @@ import site.dogether.dailytodohistory.service.DailyTodoHistoryService;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
+import site.dogether.memberactivity.entity.DailyTodoStats;
+import site.dogether.memberactivity.exception.DailyTodoStatsNotFoundException;
+import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
 import site.dogether.notification.service.NotificationService;
 
 import java.time.LocalDate;
@@ -45,6 +48,7 @@ public class DailyTodoService {
     private final ChallengeGroupMemberRepository challengeGroupMemberRepository;
     private final DailyTodoRepository dailyTodoRepository;
     private final DailyTodoCertificationRepository dailyTodoCertificationRepository;
+    private final DailyTodoStatsRepository dailyTodoStatsRepository;
     private final ReviewerPicker reviewerPicker;
     private final DailyTodoHistoryService dailyTodoHistoryService;
     private final NotificationService notificationService;
@@ -130,8 +134,11 @@ public class DailyTodoService {
         validateMemberIsInChallengeGroup(challengeGroup, writer);
         validateChallengeGroupIsRunning(challengeGroup);
 
+        final DailyTodoStats dailyTodoStats = dailyTodoStatsRepository.findByMember(writer)
+                .orElseThrow(() -> new DailyTodoStatsNotFoundException(String.format("존재하지 않는 데일리 투두 통계입니다. (%s)", dailyTodo.getMember())));
+
         final Member reviewer = reviewerPicker.pickReviewerInChallengeGroup(challengeGroup, writer).orElse(null);
-        final DailyTodoCertification dailyTodoCertification = dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl);
+        final DailyTodoCertification dailyTodoCertification = dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl, dailyTodoStats);
         dailyTodoCertificationRepository.save(dailyTodoCertification);
 
         dailyTodoHistoryService.saveDailyTodoHistory(dailyTodo, dailyTodoCertification);

--- a/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
+++ b/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
@@ -115,6 +115,7 @@ public class DailyTodoService {
         return new DailyTodos(dailyTodos);
     }
 
+    // TODO: DailyTodoStats 도메인의 increaseCertificatedCount 추가
     @Transactional
     public void certifyDailyTodo(
         final Long memberId,

--- a/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
+++ b/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
@@ -15,6 +15,9 @@ import site.dogether.dailytodohistory.service.DailyTodoHistoryService;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
+import site.dogether.memberactivity.entity.DailyTodoStats;
+import site.dogether.memberactivity.exception.DailyTodoStatsNotFoundException;
+import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
 import site.dogether.notification.service.NotificationService;
 
 import java.util.List;
@@ -29,6 +32,7 @@ public class DailyTodoCertificationService {
     private final DailyTodoCertificationRepository dailyTodoCertificationRepository;
     private final DailyTodoHistoryService dailyTodoHistoryService;
     private final NotificationService notificationService;
+    private final DailyTodoStatsRepository dailyTodoStatsRepository;
 
     @Transactional
     public void reviewDailyTodoCertification(
@@ -41,7 +45,10 @@ public class DailyTodoCertificationService {
         final DailyTodoCertification dailyTodoCertification = getDailyTodoCertification(dailyTodoCertificationId);
         final DailyTodo dailyTodo = dailyTodoCertification.getDailyTodo();
 
-        dailyTodo.review(reviewer, dailyTodoCertification, DailyTodoStatus.convertFromValue(reviewResult), rejectReason);
+        final DailyTodoStats dailyTodoStats = dailyTodoStatsRepository.findByMember(dailyTodo.getMember())
+                .orElseThrow(() -> new DailyTodoStatsNotFoundException(String.format("존재하지 않는 데일리 투두 통계입니다. (%s)", dailyTodo.getMember())));
+
+        dailyTodo.review(reviewer, dailyTodoCertification, DailyTodoStatus.convertFromValue(reviewResult), rejectReason, dailyTodoStats);
 
         dailyTodoHistoryService.saveDailyTodoHistory(dailyTodo, dailyTodoCertification);
         sendReviewResultNotificationToDailyTodoWriter(dailyTodo);

--- a/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistoryRead.java
+++ b/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistoryRead.java
@@ -10,12 +10,13 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import site.dogether.common.audit.entity.BaseEntity;
 import site.dogether.member.entity.Member;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "daily_todo_history_read")
 @Entity
-public class DailyTodoHistoryRead {
+public class DailyTodoHistoryRead extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/site/dogether/memberactivity/entity/DailyTodoStats.java
+++ b/src/main/java/site/dogether/memberactivity/entity/DailyTodoStats.java
@@ -6,6 +6,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import site.dogether.common.audit.entity.BaseEntity;
+import site.dogether.dailytodo.entity.DailyTodoStatus;
+import site.dogether.dailytodo.exception.InvalidDailyTodoStatusException;
 import site.dogether.member.entity.Member;
 
 @ToString
@@ -31,4 +33,38 @@ public class DailyTodoStats extends BaseEntity {
 
     @Column(name = "rejected_count", nullable = false, columnDefinition = "INT DEFAULT 0")
     private int rejectedCount = 0;
+
+    public DailyTodoStats(
+            final Long id,
+            final Member member,
+            final int certificatedCount,
+            final int approvedCount,
+            final int rejectedCount
+    ) {
+        this.id = id;
+        this.member = member;
+        this.certificatedCount = certificatedCount;
+        this.approvedCount = approvedCount;
+        this.rejectedCount = rejectedCount;
+    }
+
+    private void increaseCertificatedCount() {
+        this.certificatedCount += 1;
+    }
+
+    public void moveCertificatedToResult(final DailyTodoStatus result) {
+        this.certificatedCount -= 1;
+
+        if(result.equals(DailyTodoStatus.APPROVE)) {
+            this.approvedCount += 1;
+            return;
+        }
+
+        if(result.equals(DailyTodoStatus.REJECT)) {
+            this.rejectedCount += 1;
+            return;
+        }
+
+        throw new InvalidDailyTodoStatusException(String.format("존재하지 않는 데일리 투두 상태입니다. (%s)", result));
+    }
 }

--- a/src/main/java/site/dogether/memberactivity/entity/DailyTodoStats.java
+++ b/src/main/java/site/dogether/memberactivity/entity/DailyTodoStats.java
@@ -48,7 +48,7 @@ public class DailyTodoStats extends BaseEntity {
         this.rejectedCount = rejectedCount;
     }
 
-    private void increaseCertificatedCount() {
+    public void increaseCertificatedCount() {
         this.certificatedCount += 1;
     }
 

--- a/src/main/java/site/dogether/memberactivity/exception/DailyTodoStatsNotFoundException.java
+++ b/src/main/java/site/dogether/memberactivity/exception/DailyTodoStatsNotFoundException.java
@@ -1,0 +1,7 @@
+package site.dogether.memberactivity.exception;
+
+public class DailyTodoStatsNotFoundException extends RuntimeException {
+    public DailyTodoStatsNotFoundException(final String message) {
+        super(message);
+    }
+}

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
@@ -338,13 +338,14 @@ class DailyTodoTest {
             null,
             LocalDateTime.now()
         );
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final Member reviewer = createMember(2L, "투두 인증 검사자");
         final String certifyContent = "치킨 야무지게 먹은거 인증!";
         final String certifyMediaUrl = "https://치킨_냠냠.png";
 
         // When
-        final DailyTodoCertification dailyTodoCertification = dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl);
+        final DailyTodoCertification dailyTodoCertification = dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl, dailyTodoStats);
 
         // Then
         assertThat(dailyTodoCertification).isNotNull();
@@ -364,6 +365,7 @@ class DailyTodoTest {
             null,
             LocalDateTime.now()
         );
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final Member reviewer = createMember(2L, "투두 인증 검사자");
         final String certifyContent = "치킨 야무지게 먹은거 인증!";
@@ -372,7 +374,7 @@ class DailyTodoTest {
         final Member otherMember = createMember(3L, "이상한 사람");
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.certify(otherMember, reviewer, certifyContent, certifyMediaUrl))
+        assertThatThrownBy(() -> dailyTodo.certify(otherMember, reviewer, certifyContent, certifyMediaUrl, dailyTodoStats))
             .isInstanceOf(NotDailyTodoWriterException.class)
             .hasMessage(String.format("데일리 투두 작성자 외에는 투두 인증을 생성할 수 없습니다. (%s) (%s)", dailyTodo, otherMember));
     }
@@ -391,13 +393,14 @@ class DailyTodoTest {
             rejectReason,
             LocalDateTime.now()
         );
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final Member reviewer = createMember(2L, "투두 인증 검사자");
         final String certifyContent = "치킨 야무지게 먹은거 인증!";
         final String certifyMediaUrl = "https://치킨_냠냠.png";
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl))
+        assertThatThrownBy(() -> dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl, dailyTodoStats))
             .isInstanceOf(NotCertifyPendingDailyTodoException.class)
             .hasMessage(String.format("인증 대기 상태가 아닌 데일리 투두는 인증을 생성할 수 없습니다. (%s)", dailyTodo));
     }
@@ -415,13 +418,14 @@ class DailyTodoTest {
             null,
             LocalDateTime.now().minusDays(1)
         );
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final Member reviewer = createMember(2L, "투두 인증 검사자");
         final String certifyContent = "치킨 야무지게 먹은거 인증!";
         final String certifyMediaUrl = "https://치킨_냠냠.png";
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl))
+        assertThatThrownBy(() -> dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl, dailyTodoStats))
             .isInstanceOf(NotCreatedTodayDailyTodoException.class)
             .hasMessage(String.format("데일리 투두가 작성된 당일에만 투두 인증을 생성할 수 있습니다. (%s)", dailyTodo));
     }

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
@@ -18,6 +18,7 @@ import site.dogether.dailytodo.exception.NotReviewPendingDailyTodoException;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodocertification.exception.NotDailyTodoCertificationReviewerException;
 import site.dogether.member.entity.Member;
+import site.dogether.memberactivity.entity.DailyTodoStats;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -88,6 +89,16 @@ class DailyTodoTest {
             reviewer,
             "인증함!",
             "https://인증.png"
+        );
+    }
+
+    private static DailyTodoStats createDailyTodoStats(Member member) {
+        return new DailyTodoStats(
+                1L,
+                member,
+                1,
+                2,
+                3
         );
     }
 
@@ -424,12 +435,13 @@ class DailyTodoTest {
         final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, DailyTodoStatus.REVIEW_PENDING, null, LocalDateTime.now().minusHours(2));
         final Member reviewer = createMember(2L, "인증 검사자");
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = APPROVE;
         final String rejectReason = null;
 
         // When
-        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason);
+        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats);
 
         // Then
         assertSoftly(softly -> {
@@ -447,12 +459,13 @@ class DailyTodoTest {
         final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, DailyTodoStatus.REVIEW_PENDING, null, LocalDateTime.now().minusHours(2));
         final Member reviewer = createMember(2L, "인증 검사자");
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = REJECT;
         final String rejectReason = "이게 최선이야?";
 
         // When
-        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason);
+        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats);
 
         // Then
         assertSoftly(softly -> {
@@ -471,6 +484,7 @@ class DailyTodoTest {
         final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, DailyTodoStatus.REVIEW_PENDING, null, LocalDateTime.now().minusHours(2));
         final Member reviewer = createMember(2L, "인증 검사자");
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = REJECT;
         final String rejectReason = "이게 최선이야?";
@@ -478,7 +492,7 @@ class DailyTodoTest {
         final Member otherMember = createMember(3L, "이상한 사람");
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.review(otherMember, dailyTodoCertification, reviewResult, rejectReason))
+        assertThatThrownBy(() -> dailyTodo.review(otherMember, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats))
             .isInstanceOf(NotDailyTodoCertificationReviewerException.class)
             .hasMessage(String.format("해당 투두 인증 검사자 외 멤버는 검사를 수행할 수 없습니다. (%s) (%s)", otherMember, dailyTodoCertification));
     }
@@ -492,12 +506,13 @@ class DailyTodoTest {
         final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, APPROVE, null, LocalDateTime.now().minusHours(2));
         final Member reviewer = createMember(2L, "인증 검사자");
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = REJECT;
         final String rejectReason = "이게 최선이야?";
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason))
+        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats))
             .isInstanceOf(NotReviewPendingDailyTodoException.class)
             .hasMessage(String.format("검사 대기가 아닌 투두는 검사를 수행할 수 없습니다. (%s)", dailyTodo));
     }
@@ -512,11 +527,12 @@ class DailyTodoTest {
         final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, REVIEW_PENDING, null, LocalDateTime.now().minusHours(2));
         final Member reviewer = createMember(2L, "인증 검사자");
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
+        final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final String rejectReason = "이게 최선이야?";
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason))
+        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats))
             .isInstanceOf(InvalidReviewResultException.class)
             .hasMessage(String.format("검사 결과는 인정 혹은 노인정만 입력할 수 있습니다. (%s) (%s)", reviewResult, dailyTodo));
     }

--- a/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
+++ b/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
@@ -25,6 +25,8 @@ import site.dogether.fake.FakeRandomGenerator;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
+import site.dogether.memberactivity.entity.DailyTodoStats;
+import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -42,7 +44,7 @@ class DailyTodoServiceTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private ChallengeGroupMemberRepository challengeGroupMemberRepository;
     @Autowired private DailyTodoRepository dailyTodoRepository;
-    @Autowired private DailyTodoCertificationRepository dailyTodoCertificationRepository;
+    @Autowired private DailyTodoStatsRepository dailyTodoStatsRepository;
     @Autowired private DailyTodoService dailyTodoService;
     @Autowired private FakeRandomGenerator randomGenerator;
 
@@ -105,6 +107,16 @@ class DailyTodoServiceTest {
             status,
             rejectReason,
             writtenAt
+        );
+    }
+
+    private static DailyTodoStats createDailyTodoStats(Member member) {
+        return new DailyTodoStats(
+                null,
+                member,
+                1,
+                2,
+                3
         );
     }
 
@@ -276,6 +288,7 @@ class DailyTodoServiceTest {
             null,
             LocalDateTime.now()
         ));
+        dailyTodoStatsRepository.save(createDailyTodoStats(writer));
 
         final Long writerId = writer.getId();
         final Long dailyTodoId = dailyTodo.getId();
@@ -313,6 +326,7 @@ class DailyTodoServiceTest {
             null,
             LocalDateTime.now()
         ));
+        dailyTodoStatsRepository.save(createDailyTodoStats(writer));
 
         randomGenerator.setResult(2); // 검사자로 썬이 선정되도록 조작
 

--- a/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
@@ -17,6 +17,8 @@ import site.dogether.dailytodocertification.repository.DailyTodoCertificationRep
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
+import site.dogether.memberactivity.entity.DailyTodoStats;
+import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -33,6 +35,7 @@ class DailyTodoCertificationServiceTest {
     @Autowired private MemberRepository memberRepository;
     @Autowired private DailyTodoRepository dailyTodoRepository;
     @Autowired private DailyTodoCertificationRepository dailyTodoCertificationRepository;
+    @Autowired private DailyTodoStatsRepository dailyTodoStatsRepository;
     @Autowired private DailyTodoCertificationService dailyTodoCertificationService;
 
     private static ChallengeGroup createChallengeGroup() {
@@ -85,6 +88,16 @@ class DailyTodoCertificationServiceTest {
             "https://인증.png"
         );
     }
+
+    private static DailyTodoStats createDailyTodoStats(Member member) {
+        return new DailyTodoStats(
+                null,
+                member,
+                1,
+                2,
+                3
+        );
+    }
     
     @DisplayName("인정에 대해 유효한 검사 값(검사자 id, 투두 인증 id, 검사 결과, 노인정 사유)을 넘기면 투두 인증 검사를 수행하고 변경된 부분을 DB에 반영 요청 한다.")
     @Test
@@ -95,6 +108,7 @@ class DailyTodoCertificationServiceTest {
         final DailyTodo dailyTodo = dailyTodoRepository.save(createDailyTodo(challengeGroup, writer, REVIEW_PENDING, null, LocalDateTime.now()));
         final Member reviewer = memberRepository.save(createMember("인증 검사자"));
         final DailyTodoCertification dailyTodoCertification = dailyTodoCertificationRepository.save(createDailyTodoCertification(dailyTodo, reviewer));
+        dailyTodoStatsRepository.save(createDailyTodoStats(writer));
 
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();
@@ -119,6 +133,7 @@ class DailyTodoCertificationServiceTest {
         final DailyTodo dailyTodo = dailyTodoRepository.save(createDailyTodo(challengeGroup, writer, REVIEW_PENDING, null, LocalDateTime.now()));
         final Member reviewer = memberRepository.save(createMember("인증 검사자"));
         final DailyTodoCertification dailyTodoCertification = dailyTodoCertificationRepository.save(createDailyTodoCertification(dailyTodo, reviewer));
+        dailyTodoStatsRepository.save(createDailyTodoStats(writer));
 
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();


### PR DESCRIPTION
### 수정사항
투두 검사로 인해 투두 상태가 변경될 때 사용자 별 데일리 투두 통계 값을 변경할 수 있도록 추가

- 사용자가 투두를 인증할 때 통계 값 변경 (certificated_count 값 증가)
- 투두를 누군가 검사할 때 사용자의 통계 값 변경 (certificated_count 값 감소, approved_count or rejected_count 증가)

This closes #83