### PR TITLE
[BE] 챌린지 그룹 중복 참여 오류 수정

### DIFF
--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupMember.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupMember.java
@@ -1,6 +1,14 @@
 package site.dogether.challengegroup.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,7 +19,8 @@ import site.dogether.member.entity.Member;
 @ToString
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "challenge_group_member")
+@Table(name = "challenge_group_member",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"challenge_group_id", "member_id"}))
 @Entity
 public class ChallengeGroupMember extends BaseEntity {
 


### PR DESCRIPTION
챌린지 그룹 중복 참여 오류를 수정합니다.

### 문제 원인

기존에도 서비스에서 그룹에 참여하려는 유저가 해당 그룹에 이미 속해있는지 검증은 존재했습니다.
하지만 일명 "따닥"과 같은 동시 요청이 들어오는 경우 애플리케이션 단의 선행 검증만으로 중복 삽입을 완벽히 막을 수 없습니다.
이런 상황에서는 두 요청이 동시에 exists 검사를 통과한 후,
각각 save를 시도하게 되면서 결과적으로 동일 유저가 같은 그룹에 중복 참여하는 문제가 발생합니다.

### 해결 방법
따라서 DB 차원에서 challenge_group_id와 member_id의 조합에 유니크 제약조건을 걸어
동시에 insert가 시도되더라도 하나는 DB에서 막히고 예외를 발생시킬 수 있도록 수정합니다.
