### PR TITLE
[BE] 회원 재가입 시 발생하는 오류 수정

### DIFF
--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -9,6 +9,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,9 +21,6 @@ import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.member.exception.InvalidMemberException;
 import site.dogether.memberactivity.entity.DailyTodoStats;
 import site.dogether.notification.entity.NotificationToken;
-
-import java.util.List;
-import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,7 +35,7 @@ public class Member extends BaseEntity {
     @Column(name = "provider_id", length = 100, nullable = false, unique = true)
     private String providerId;
 
-    @Column(name = "name", length = 20, nullable = false, unique = true)
+    @Column(name = "name", length = 20, nullable = false)
     private String name;
 
     @Column(name = "profile_image_url", length = 500, nullable = false)

--- a/src/main/java/site/dogether/member/service/MemberService.java
+++ b/src/main/java/site/dogether/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package site.dogether.member.service;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -8,8 +9,6 @@ import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
 import site.dogether.memberactivity.service.MemberActivityService;
-
-import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -42,8 +41,9 @@ public class MemberService {
     }
 
     private void hardDelete(Member member) {
-        log.info("재가입을 위한 회원 정보 삭제. memberId: {}", member.getId());
         memberRepository.delete(member);
+        memberRepository.flush();
+        log.info("재가입을 위한 회원 정보 삭제. memberId: {}", member.getId());
     }
 
     private Member createMember(String providerId, String name) {

--- a/src/test/java/site/dogether/member/service/MemberServiceTest.java
+++ b/src/test/java/site/dogether/member/service/MemberServiceTest.java
@@ -1,0 +1,74 @@
+package site.dogether.member.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import site.dogether.challengegroup.entity.ChallengeGroup;
+import site.dogether.challengegroup.entity.ChallengeGroupMember;
+import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
+import site.dogether.challengegroup.repository.ChallengeGroupRepository;
+import site.dogether.member.entity.Member;
+
+
+@SpringBootTest(webEnvironment = WebEnvironment.NONE)
+class MemberServiceTest {
+
+    @Autowired private MemberService memberService;
+    @Autowired private MemberWithdrawService memberWithdrawService;
+    @Autowired private ChallengeGroupRepository challengeGroupRepository;
+    @Autowired private ChallengeGroupMemberRepository challengeGroupMemberRepository;
+
+    @Test
+    void 신규_회원을_저장한다() {
+        // given
+        String providerId = "providerId";
+        String name = "폰트";
+
+        // when
+        Member saved = memberService.save(providerId, name);
+
+        // then
+        assertThat(saved.getProviderId()).isEqualTo(providerId);
+    }
+
+    @Test
+    void 이미_가입된_회원이면_저장하지_않고_조회한다() {
+        // given
+        String providerId = "providerId";
+        String name = "폰트";
+        Member saved = memberService.save(providerId, name);
+
+        // when
+        Member found = memberService.save(providerId, name);
+
+        // then
+        assertThat(found.getId()).isEqualTo(saved.getId());
+    }
+
+    @Test
+    void 탈퇴한_회원이_다시_가입하면_논리_삭제했던_정보를_물리_삭제하고_새로_저장한다() {
+        // given
+        String providerId = "providerId";
+        String name = "폰트";
+        Member member = memberService.save(providerId, name);
+        ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
+                "그룹", 10, LocalDate.now(), LocalDate.now().plusDays(3)
+        ));
+        ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.save(
+                new ChallengeGroupMember(challengeGroup, member));
+
+        memberWithdrawService.delete(member.getId());
+
+        // when
+        Member found = memberService.save(providerId, name);
+
+        // then
+        assertThat(found.getId()).isNotEqualTo(member.getId());
+        assertThat(challengeGroupMemberRepository.findById(challengeGroupMember.getId()))
+                .isEmpty();
+    }
+}


### PR DESCRIPTION
### 문제 상황

- 탈퇴한 회원이 동일한 providerId로 재가입 시, 기존 회원을 삭제한 후 insert하는 로직에서 오류가 발생했습니다.
- JPA의 쓰기 지연으로 인해 먼저 수행되는 delete 쿼리가 insert보다 db에 늦게 나가면서 member의 name에 걸려있던 유니크 제약에 걸리는 것을 확인했습니다.

### 해결 방법

- 회원 삭제 후 flush를 호출해 delete 쿼리를 db에 즉시 반영하도록 수정했습니다.
- name의 유니크 제약을 삭제했습니다. (현재 애플에서 내려오는 사용자 이름을 name으로 사용하고 있는데 이는 같을 수 있으므로)

