### PR TITLE
 [BE] 그룹원 랭킹 계산 오류 해결

### DIFF
--- a/src/main/java/site/dogether/challengegroup/entity/AchievementRateCalculator.java
+++ b/src/main/java/site/dogether/challengegroup/entity/AchievementRateCalculator.java
@@ -1,26 +1,31 @@
 package site.dogether.challengegroup.entity;
 
-import site.dogether.dailytodo.entity.DailyTodos;
+import site.dogether.dailytodo.entity.DailyTodo;
 
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class AchievementRateCalculator {
 
     public static int calculate(
-        final DailyTodos todos,
+        List<DailyTodo> dailyTodos,
         final LocalDateTime challengeGroupJoinedAt,
         final LocalDate challengeGroupStartAt,
         final LocalDate challengeGroupEndAt
     ) {
-        if (todos.isEmpty()) {
+        if (dailyTodos.isEmpty()) {
             return 0;
         }
-
-        final int totalTodoCount = todos.totalCount();
-        final int certificatedTodoCount = todos.certificatedCount();
-        final int approvedTodoCount = todos.approvedCount();
+        // TODO: 추후 해당 로직 리팩토링 필요
+        final int totalTodoCount = dailyTodos.size();
+        final int certificatedTodoCount = (int) dailyTodos.stream()
+            .filter(DailyTodo::isCertified)
+            .count();
+        final int approvedTodoCount = (int) dailyTodos.stream()
+            .filter(DailyTodo::isApproved)
+            .count();
 
         final double certificationRate = (double) certificatedTodoCount / totalTodoCount;
         final double approvalRate = (double) approvedTodoCount / certificatedTodoCount;

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -220,7 +220,7 @@ public class ChallengeGroupService {
                 final ChallengeGroup challengeGroup = groupMember.getChallengeGroup();
                 final List<DailyTodo> todos = dailyTodoService.getMemberTodos(challengeGroup, groupMember.getMember());
                 final int achievementRate = AchievementRateCalculator.calculate(
-                    new DailyTodos(todos),
+                    todos,
                     groupMember.getCreatedAt(),
                     challengeGroup.getStartAt(),
                     challengeGroup.getEndAt()

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodos.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodos.java
@@ -30,20 +30,4 @@ public class DailyTodos {
     public boolean isEmpty() {
         return values.isEmpty();
     }
-
-    public int totalCount() {
-        return values.size();
-    }
-
-    public int certificatedCount() {
-        return (int) values.stream()
-            .filter(DailyTodo::isCertified)
-            .count();
-    }
-
-    public int approvedCount() {
-        return (int) values.stream()
-            .filter(DailyTodo::isApproved)
-            .count();
-    }
 }


### PR DESCRIPTION
### 문제 상황
기존에 데일리 투두들을 계산하는 로직을 dailyTodos를 활용하고자 하였는데 dailyTodos는 투두가 null일 경우 예외처리를 진행하고 있어, 투두가 없으면 투두들을 조회하지 못하는 문제 발생

### 추가 설명
지금 당장은 투두들을 계산하는 로직을 다른 곳으로 이동한 후 추후 다시 리팩토링 진행 예정

This closes #86