### PR TITLE
 [BE] 그룹원 랭킹 계산 오류 해결

### DIFF
--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -240,7 +240,7 @@ public class ChallengeGroupService {
     private List<ChallengeGroupMemberOverviewDto> buildChallengeGroupOverview(final Member viewer, final List<ChallengeGroupMemberWithAchievementRateDto> challengeGroupMemberWithAchievementRates) {
         return challengeGroupMemberWithAchievementRates.stream()
             .map(dto -> new ChallengeGroupMemberOverviewDto(
-                dto.challengeGroupMember().getId(),
+                dto.challengeGroupMember().getMember().getId(),
                 challengeGroupMemberWithAchievementRates.indexOf(dto) + 1,
                 dto.challengeGroupMember().getMember().getProfileImageUrl(),
                 dto.challengeGroupMember().getMember().getName(),


### PR DESCRIPTION
### 문제 상황
challengeGroupMember의 id를 조회하면서 문제가 발생

### 수정 사항
챌린지 그룹 멤버의 멤버 id를 조회하도록 수정

This closes #86