### PR TITLE
 [BE] 참여중인 특정 챌린지 그룹 활동 통계 조회 api 로직 수정

### DIFF
--- a/src/main/java/site/dogether/dailytodo/entity/MyTodoSummary.java
+++ b/src/main/java/site/dogether/dailytodo/entity/MyTodoSummary.java
@@ -13,17 +13,10 @@ public class MyTodoSummary {
         this.myTodos = myTodos;
     }
 
-    public int calculateTotalTodoCount() {
-        return myTodos.size();
-    }
-
     public int calculateTotalCertificatedCount() {
-        int totalTodoCount = calculateTotalTodoCount();
-        int certifyPendingCount = (int) myTodos.stream()
-            .filter(DailyTodo::isCertifyPending)
+        return (int) myTodos.stream()
+            .filter(DailyTodo::isCertified)
             .count();
-
-        return totalTodoCount - certifyPendingCount;
     }
 
     public int calculateTotalApprovedCount() {

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -138,7 +138,7 @@ public class MemberActivityService {
         final int createdCount = todos.size();
 
         final int certificatedCount = (int) todos.stream()
-                .filter(todo -> todo.getStatus() == DailyTodoStatus.APPROVE)
+                .filter(DailyTodo::isCertified)
                 .count();
 
         final int certificationRate = calculateCertificationRate(createdCount, certificatedCount);


### PR DESCRIPTION
### 문제 상황
인정받은 투두만 인증된 투두로 카운팅되면서 문제 발생

### 수정 사항
인정, 노인정, 검사 대기 중인 투두들을 카운팅 할 수 있도록 수정

This closes #102