### PR TITLE
[BE] 참여중인 특정 챌린지 그룹 활동 통계 조회 api 로직 수정

### DIFF
--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -155,7 +155,7 @@ public class MemberActivityService {
         if (createdCount == 0) {
             return 0;
         }
-        return (int) ((double) (certificatedCount / createdCount) * 100);
+        return (int) (((double) certificatedCount / createdCount) * 100);
     }
 
     public GetGroupActivityStatResponse.RankingResponse getMyRank(final Member target, final List<ChallengeGroupMember> groupMembers, final ChallengeGroup challengeGroup) {


### PR DESCRIPTION
### 수정사항
certificatedRate를 double 타입으로 계산할 수 있도록 수정

This closes #102