### PR TITLE
투두 피드백 기능 & 가장 마지막에 선택한 그룹 id 조회 관련 API 명세 최신화

### DIFF
--- a/src/docs/asciidoc/challengegroup/challenge-group.adoc
+++ b/src/docs/asciidoc/challengegroup/challenge-group.adoc
@@ -88,7 +88,27 @@ include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-g
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/http-response.adoc[]
 include::{snippets}/challenge-group-controller-docs-test/get-joining-challenge-groups/response-fields.adoc[]
 
-[[get-challenge-group]]
+[[save-last-selected-challenge-group-info]]
+=== 사용자가 가장 마지막에 선택한 챌린지 그룹 id 저장
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| X
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/challenge-group-controller-docs-test/save-last-selected-challenge-group-info/http-request.adoc[]
+include::{snippets}/challenge-group-controller-docs-test/save-last-selected-challenge-group-info/request-fields.adoc[]
+
+==== HTTP Response
+include::{snippets}/challenge-group-controller-docs-test/save-last-selected-challenge-group-info/http-response.adoc[]
+include::{snippets}/challenge-group-controller-docs-test/save-last-selected-challenge-group-info/response-fields.adoc[]
 
 [[get-joining-challenge-group-team-activity-summary]]
 === 참여중인 특정 챌린지 그룹의 그룹원 전체 랭킹 조회

--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.challengegroup.controller.request.CreateChallengeGroupRequest;
 import site.dogether.challengegroup.controller.request.JoinChallengeGroupRequest;
+import site.dogether.challengegroup.controller.request.SaveLastSelectedChallengeGroupInfoRequest;
 import site.dogether.challengegroup.controller.response.CreateChallengeGroupResponse;
 import site.dogether.challengegroup.controller.response.GetChallengeGroupMembersRankResponse;
 import site.dogether.challengegroup.controller.response.GetJoiningChallengeGroupsResponse;
@@ -20,7 +21,7 @@ import site.dogether.challengegroup.controller.response.JoinChallengeGroupRespon
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.ChallengeGroupMemberOverviewDto;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
-import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
+import site.dogether.challengegroup.service.dto.JoiningChallengeGroupsWithLastSelectedGroupIndexDto;
 import site.dogether.common.controller.response.ApiResponse;
 
 import java.util.List;
@@ -63,12 +64,20 @@ public class ChallengeGroupController {
     public ResponseEntity<ApiResponse<GetJoiningChallengeGroupsResponse>> getJoiningChallengeGroups(
             @Authenticated final Long memberId
     ) {
-        final List<JoiningChallengeGroupDto> joiningChallengeGroups = challengeGroupService.getJoiningChallengeGroups(memberId);
+        final JoiningChallengeGroupsWithLastSelectedGroupIndexDto joiningChallengeGroups = challengeGroupService.getJoiningChallengeGroups(memberId);
         return ResponseEntity.ok(
             ApiResponse.successWithData(
                 GET_JOINING_CHALLENGE_GROUPS,
-                new GetJoiningChallengeGroupsResponse(joiningChallengeGroups))
+                new GetJoiningChallengeGroupsResponse(joiningChallengeGroups.lastSelectedGroupIndex(), joiningChallengeGroups.joiningChallengeGroups()))
         );
+    }
+
+    @PostMapping("/last-selected")
+    public ResponseEntity<ApiResponse<Void>> saveLastSelectedChallengeGroupInfo(
+        @Authenticated final Long memberId,
+        @RequestBody final SaveLastSelectedChallengeGroupInfoRequest request
+    ) {
+        return ResponseEntity.ok(ApiResponse.success(SAVE_LAST_SELECTED_CHALLENGE_GROUP_ID));
     }
 
     @DeleteMapping("/{groupId}/leave")

--- a/src/main/java/site/dogether/challengegroup/controller/request/SaveLastSelectedChallengeGroupInfoRequest.java
+++ b/src/main/java/site/dogether/challengegroup/controller/request/SaveLastSelectedChallengeGroupInfoRequest.java
@@ -1,0 +1,4 @@
+package site.dogether.challengegroup.controller.request;
+
+public record SaveLastSelectedChallengeGroupInfoRequest(Long groupId) {
+}

--- a/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/ChallengeGroupSuccessCode.java
@@ -15,6 +15,7 @@ public enum ChallengeGroupSuccessCode implements SuccessCode {
     IS_PARTICIPATING_CHALLENGE_GROUP("CGS-0005", "챌린지 그룹 참여 여부를 조회하였습니다."),
     GET_JOINING_CHALLENGE_GROUP_TEAM_ACTIVITY_SUMMARY("CGS-0007", "참여중인 그룹의 팀 전체 누적 활동 통계 정보를 조회하였습니다."),
     LEAVE_CHALLENGE_GROUP("CGS-0008", "챌린지 그룹을 탈퇴하였습니다."),
+    SAVE_LAST_SELECTED_CHALLENGE_GROUP_ID("CGS-0009", "사용자가 가장 마지막에 선택한 챌린지 그룹 id를 저장하였습니다."),
     ;
 
     private final String value;

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupsResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupsResponse.java
@@ -1,7 +1,12 @@
 package site.dogether.challengegroup.controller.response;
 
-import java.util.List;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
 
-public record GetJoiningChallengeGroupsResponse(List<JoiningChallengeGroupDto> joiningChallengeGroups) {
-}
+import java.util.List;
+
+public record GetJoiningChallengeGroupsResponse(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    int lastSelectedGroupIndex,
+    List<JoiningChallengeGroupDto> joiningChallengeGroups
+) {}

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -22,8 +22,8 @@ import site.dogether.challengegroup.service.dto.ChallengeGroupMemberOverviewDto;
 import site.dogether.challengegroup.service.dto.ChallengeGroupMemberWithAchievementRateDto;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
+import site.dogether.challengegroup.service.dto.JoiningChallengeGroupsWithLastSelectedGroupIndexDto;
 import site.dogether.dailytodo.entity.DailyTodo;
-import site.dogether.dailytodo.entity.DailyTodos;
 import site.dogether.dailytodo.service.DailyTodoService;
 import site.dogether.dailytodohistory.service.DailyTodoHistoryService;
 import site.dogether.member.entity.Member;
@@ -154,7 +154,7 @@ public class ChallengeGroupService {
         }
     }
 
-    public List<JoiningChallengeGroupDto> getJoiningChallengeGroups(final Long memberId) {
+    public JoiningChallengeGroupsWithLastSelectedGroupIndexDto getJoiningChallengeGroups(final Long memberId) {
         final Member member = getMember(memberId);
 
         final List<ChallengeGroupMember> challengeGroupMembers = challengeGroupMemberRepository.findNotFinishedGroupByMember(member);
@@ -162,11 +162,13 @@ public class ChallengeGroupService {
             .map(ChallengeGroupMember::getChallengeGroup)
             .toList();
 
-        return joiningGroups.stream()
+        final List<JoiningChallengeGroupDto> joiningChallengeGroupDtos = joiningGroups.stream()
             .map(joiningGroup -> JoiningChallengeGroupDto.from(
                 joiningGroup,
                 challengeGroupMemberRepository.countByChallengeGroup(joiningGroup)))
             .toList();
+
+        return new JoiningChallengeGroupsWithLastSelectedGroupIndexDto(1, joiningChallengeGroupDtos);
     }
 
     @Transactional

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupsWithLastSelectedGroupIndexDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupsWithLastSelectedGroupIndexDto.java
@@ -1,0 +1,8 @@
+package site.dogether.challengegroup.service.dto;
+
+import java.util.List;
+
+public record JoiningChallengeGroupsWithLastSelectedGroupIndexDto(
+    int lastSelectedGroupIndex,
+    List<JoiningChallengeGroupDto> joiningChallengeGroups
+) {}

--- a/src/main/java/site/dogether/dailytodo/controller/response/GetMyDailyTodosResponse.java
+++ b/src/main/java/site/dogether/dailytodo/controller/response/GetMyDailyTodosResponse.java
@@ -27,7 +27,7 @@ record Data(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     String certificationMediaUrl,
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    String rejectReason
+    String reviewFeedback
 ) {
     public static Data from(final DailyTodoAndDailyTodoCertificationDto dailyTodo) {
         return new Data(

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -137,10 +137,6 @@ public class DailyTodo extends BaseEntity {
     }
 
     private void validateRejectReason(final DailyTodoStatus status, final String rejectReason) {
-        if (status != REJECT && rejectReason != null) {
-            throw new InvalidDailyTodoException(String.format("데일리 투두가 노인정 상태가 아니면 노인정 사유를 입력할 수 없습니다. (%s)", rejectReason));
-        }
-
         if (status == REJECT && (rejectReason == null || rejectReason.isBlank())) {
             throw new InvalidDailyTodoException(String.format("노인정 사유로 null 혹은 공백을 입력할 수 없습니다. (%s)", rejectReason));
         }

--- a/src/main/java/site/dogether/dailytodo/service/dto/DailyTodoAndDailyTodoCertificationDto.java
+++ b/src/main/java/site/dogether/dailytodo/service/dto/DailyTodoAndDailyTodoCertificationDto.java
@@ -52,7 +52,7 @@ public class DailyTodoAndDailyTodoCertificationDto {
     }
 
     public Optional<String> findRejectReason() {
-        if (dailyTodoCertification == null || dailyTodo.getStatus() != DailyTodoStatus.REJECT) {
+        if (dailyTodoCertification == null || !dailyTodo.getStatus().isReviewResultStatus()) {
             return Optional.empty();
         }
 

--- a/src/main/java/site/dogether/dailytodocertification/controller/DailyTodoCertificationController.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/DailyTodoCertificationController.java
@@ -51,7 +51,7 @@ public class DailyTodoCertificationController {
             memberId,
             todoCertificationId,
             request.result(),
-            request.rejectReason()
+            request.reviewFeedback()
         );
         return ResponseEntity.ok(ApiResponse.success(REVIEW_DAILY_TODO_CERTIFICATION));
     }

--- a/src/main/java/site/dogether/dailytodocertification/controller/request/ReviewDailyTodoCertificationRequest.java
+++ b/src/main/java/site/dogether/dailytodocertification/controller/request/ReviewDailyTodoCertificationRequest.java
@@ -1,4 +1,4 @@
 package site.dogether.dailytodocertification.controller.request;
 
-public record ReviewDailyTodoCertificationRequest(String result, String rejectReason) {
+public record ReviewDailyTodoCertificationRequest(String result, String reviewFeedback) {
 }

--- a/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
+++ b/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
@@ -39,7 +39,7 @@ public class DailyTodoCertificationService {
         final Long reviewerId,
         final Long dailyTodoCertificationId,
         final String reviewResult,
-        final String rejectReason
+        final String reviewFeedback
     ) {
         final Member reviewer = getMember(reviewerId);
         final DailyTodoCertification dailyTodoCertification = getDailyTodoCertification(dailyTodoCertificationId);
@@ -48,7 +48,7 @@ public class DailyTodoCertificationService {
         final DailyTodoStats dailyTodoStats = dailyTodoStatsRepository.findByMember(dailyTodo.getMember())
                 .orElseThrow(() -> new DailyTodoStatsNotFoundException(String.format("존재하지 않는 데일리 투두 통계입니다. (%s)", dailyTodo.getMember())));
 
-        dailyTodo.review(reviewer, dailyTodoCertification, DailyTodoStatus.convertFromValue(reviewResult), rejectReason, dailyTodoStats);
+        dailyTodo.review(reviewer, dailyTodoCertification, DailyTodoStatus.convertFromValue(reviewResult), reviewFeedback, dailyTodoStats);
 
         dailyTodoHistoryService.saveDailyTodoHistory(dailyTodo, dailyTodoCertification);
         sendReviewResultNotificationToDailyTodoWriter(dailyTodo);

--- a/src/main/java/site/dogether/memberactivity/controller/response/GetMemberAllStatsResponse.java
+++ b/src/main/java/site/dogether/memberactivity/controller/response/GetMemberAllStatsResponse.java
@@ -38,7 +38,7 @@ public record GetMemberAllStatsResponse(
             String certificationContent,
             String certificationMediaUrl,
             @JsonInclude(JsonInclude.Include.NON_NULL)
-            String rejectReason
+            String reviewFeedback
     ) {
     }
 }

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
@@ -214,23 +214,6 @@ class DailyTodoTest {
             .hasMessage("데일리 투두 상태로 null을 입력할 수 없습니다.");
     }
 
-    @DisplayName("데일리 투두가 노인정 상태가 아닐 때 노인정 사유가 입력되면 예외가 발생한다.")
-    @Test()
-    void throwExceptionWhenStatusNotRejectAndInputRejectReason() {
-        // Given
-        final ChallengeGroup challengeGroup = createChallengeGroup();
-        final Member member = createMember();
-        final String content = "치킨 먹기";
-        final DailyTodoStatus status = APPROVE;
-        final String rejectReason = "이딴게 치킨?";
-        final LocalDateTime writtenAt = LocalDateTime.now();
-
-        // When & Then
-        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, status, rejectReason, writtenAt))
-            .isInstanceOf(InvalidDailyTodoException.class)
-            .hasMessage(String.format("데일리 투두가 노인정 상태가 아니면 노인정 사유를 입력할 수 없습니다. (%s)", rejectReason));
-    }
-
     @DisplayName("데일리 투두가 노인정 상태일 때 노인정 사유로 null 혹은 공백이 입력되면 예외가 발생한다.")
     @NullAndEmptySource
     @ParameterizedTest()

--- a/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/challengegroup/ChallengeGroupControllerDocsTest.java
@@ -7,11 +7,13 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import site.dogether.challengegroup.controller.ChallengeGroupController;
 import site.dogether.challengegroup.controller.request.CreateChallengeGroupRequest;
 import site.dogether.challengegroup.controller.request.JoinChallengeGroupRequest;
+import site.dogether.challengegroup.controller.request.SaveLastSelectedChallengeGroupInfoRequest;
 import site.dogether.challengegroup.controller.response.IsParticipatingChallengeGroupResponse;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.challengegroup.service.dto.ChallengeGroupMemberOverviewDto;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
 import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
+import site.dogether.challengegroup.service.dto.JoiningChallengeGroupsWithLastSelectedGroupIndexDto;
 import site.dogether.docs.util.RestDocsSupport;
 
 import java.util.List;
@@ -165,9 +167,10 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     2,
                     0.5)
         );
+        final JoiningChallengeGroupsWithLastSelectedGroupIndexDto joiningChallengeGroupsWithLastSelectedGroupIndexDto = new JoiningChallengeGroupsWithLastSelectedGroupIndexDto(1, joiningChallengeGroups);
 
         given(challengeGroupService.getJoiningChallengeGroups(any()))
-            .willReturn(joiningChallengeGroups);
+            .willReturn(joiningChallengeGroupsWithLastSelectedGroupIndexDto);
 
         mockMvc.perform(
                 get("/api/groups/my")
@@ -182,6 +185,10 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                     fieldWithPath("message")
                         .description("응답 메시지")
                         .type(JsonFieldType.STRING),
+                    fieldWithPath("data.lastSelectedGroupIndex")
+                        .description("가장 마지막에 선택한 챌린지 그룹 인덱스")
+                        .type(JsonFieldType.NUMBER)
+                        .optional(),
                     fieldWithPath("data.joiningChallengeGroups")
                         .description("참여중인 챌린지 그룹")
                         .type(JsonFieldType.ARRAY)
@@ -218,6 +225,32 @@ public class ChallengeGroupControllerDocsTest extends RestDocsSupport {
                         .description("활동 진행률")
                         .type(JsonFieldType.NUMBER)
                 )));
+    }
+
+    @DisplayName("사용자가 가장 마지막에 선택한 챌린지 그룹 id 저장 API")
+    @Test
+    void saveLastSelectedChallengeGroupInfo() throws Exception {
+        final SaveLastSelectedChallengeGroupInfoRequest request = new SaveLastSelectedChallengeGroupInfoRequest(1L);
+
+        mockMvc.perform(
+                post("/api/groups/last-selected")
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE)
+                    .content(convertToJson(request)))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                requestFields(
+                    fieldWithPath("groupId")
+                        .description("사용자가 마지막에 선택한 챌린지 그룹 id")
+                        .type(JsonFieldType.NUMBER)
+                        .attributes(constraints("현재 진행중이면서 사용자가 참여중인 챌린지 그룹 id만 입력 허용"))),
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING))));
     }
 
     @DisplayName("챌린지 그룹 탈퇴 API")

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -124,7 +124,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
         final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING);
         final List<DailyTodo> dailyTodos = List.of(
             new DailyTodo(1L, challengeGroup, doer, "운동 하기", REVIEW_PENDING, null, LocalDateTime.now()),
-            new DailyTodo(2L, challengeGroup, doer, "인강 듣기", APPROVE, null, LocalDateTime.now()),
+            new DailyTodo(2L, challengeGroup, doer, "인강 듣기", APPROVE, "와.. 오늘 이걸 다 들었어요...?", LocalDateTime.now()),
             new DailyTodo(3L, challengeGroup, doer, "치킨 먹기", CERTIFY_PENDING, null, LocalDateTime.now()),
             new DailyTodo(4L, challengeGroup, doer, "DND API 구현", REJECT, "코드 개판이네 ㅎ", LocalDateTime.now())
         );
@@ -183,8 +183,8 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .description("데일리 투두 인증글 이미지 URL")
                         .optional()
                         .type(JsonFieldType.STRING),
-                    fieldWithPath("data.todos[].rejectReason")
-                        .description("데일리 투두 인증 노인정 사유")
+                    fieldWithPath("data.todos[].reviewFeedback")
+                        .description("데일리 투두 인증 검사 피드백")
                         .optional()
                         .type(JsonFieldType.STRING))));
     }

--- a/src/test/java/site/dogether/docs/dailytodocertification/DailyTodoCertificationControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodocertification/DailyTodoCertificationControllerDocsTest.java
@@ -98,11 +98,10 @@ public class DailyTodoCertificationControllerDocsTest extends RestDocsSupport {
                         .description("검사 결과")
                         .type(JsonFieldType.STRING)
                         .attributes(constraints("시스템에서 제공하는 값만 입력 가능, [ APPROVE(인정), REJECT(노인정) ]")),
-                    fieldWithPath("rejectReason")
-                        .description("노인정 사유")
+                    fieldWithPath("reviewFeedback")
+                        .description("검사 피드백")
                         .type(JsonFieldType.STRING)
-                        .optional()
-                        .attributes(constraints("노인정일 경우에만 사유 입력, 인정과 함께 해당 필드의 데이터를 보내면 해당 데이터는 무시됨."))),
+                        .attributes(constraints("인정, 노인정 상관없이 필수로 작성. 60자 이하 문자열만 입력 가능."))),
                 responseFields(
                     fieldWithPath("code")
                         .description("응답 코드")

--- a/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/controller/MemberActivityControllerDocsTest.java
@@ -148,7 +148,7 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         "APPROVE",
                                         "운동 개조짐 ㅋㅋㅋㅋ",
                                         "운동 조지는 짤.png",
-                                        null
+                                        "저도 같이 해요..."
                                 )
                         )
                 ),
@@ -161,7 +161,7 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                         "APPROVE",
                                         "인강 진짜 열심히 들었습니다. ㅎ",
                                         "인강 달리는 짤.png",
-                                        null
+                                        "얼마나 더 똑똑해지려고 ㄷㄷ"
                                 )
                         )
                 )
@@ -230,8 +230,8 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.certificationsGroupedByTodoCompletedAt[].certificationInfo[].certificationMediaUrl")
                                         .description("데일리 투두 인증글 이미지 URL")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.certificationsGroupedByTodoCompletedAt[].certificationInfo[].rejectReason")
-                                        .description("데일리 투두 인증 노인정 사유")
+                                fieldWithPath("data.certificationsGroupedByTodoCompletedAt[].certificationInfo[].reviewFeedback")
+                                        .description("데일리 투두 인증 검사 피드백")
                                         .optional()
                                         .type(JsonFieldType.STRING))));
     }
@@ -337,8 +337,8 @@ class MemberActivityControllerDocsTest extends RestDocsSupport {
                                 fieldWithPath("data.certificationsGroupedByGroupCreatedAt[].certificationInfo[].certificationMediaUrl")
                                         .description("데일리 투두 인증글 이미지 URL")
                                         .type(JsonFieldType.STRING),
-                                fieldWithPath("data.certificationsGroupedByGroupCreatedAt[].certificationInfo[].rejectReason")
-                                        .description("데일리 투두 인증 노인정 사유")
+                                fieldWithPath("data.certificationsGroupedByGroupCreatedAt[].certificationInfo[].reviewFeedback")
+                                        .description("데일리 투두 인증 검사 피드백")
                                         .optional()
                                         .type(JsonFieldType.STRING))));
     }


### PR DESCRIPTION
투두 피드백 기능 & 가장 마지막에 선택한 그룹 id 조회 관련 API 명세를 최신화 하였습니다.
- 검사 피드백 기능 추가 관련 API 명세 수정
  - 데일리 투두 수행 인증 검사 요청값 문서 수정
  - 참여중인 특정 챌린지 그룹에서 내 데일리 투두 전체 조회 (투두 작성 날짜만 입력) 응답값 문서에 검사 결과 필드 반영
  - 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 (투두 완료일 순) 응답값 문서에 검사 결과 필드 반영
  - 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 (그룹 생성일 순) 응답값 문서에 검사 결과 필드 반영
- 가장 마지막에 선택한 챌린지 그룹 id조회 기능 추가 관련 API 명세 수정
  - 가장 마지막에 선택한 챌린지 그룹 id저장 API 문서 생성
  - 참여중인 챌린지 그룹 정보 전체 조회 응답값 문서에 검사 결과 필드 반영

This closes #114 