### PR TITLE
투두 인증 검사 피드백 & 사용자가 가장 마지막에 선택한 그룹의 정보 저장 기능 구현

### DIFF
--- a/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
+++ b/src/main/java/site/dogether/challengegroup/controller/ChallengeGroupController.java
@@ -77,6 +77,7 @@ public class ChallengeGroupController {
         @Authenticated final Long memberId,
         @RequestBody final SaveLastSelectedChallengeGroupInfoRequest request
     ) {
+        challengeGroupService.saveLastSelectedChallengeGroupRecord(memberId, request.groupId());
         return ResponseEntity.ok(ApiResponse.success(SAVE_LAST_SELECTED_CHALLENGE_GROUP_ID));
     }
 

--- a/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupsResponse.java
+++ b/src/main/java/site/dogether/challengegroup/controller/response/GetJoiningChallengeGroupsResponse.java
@@ -7,6 +7,6 @@ import java.util.List;
 
 public record GetJoiningChallengeGroupsResponse(
     @JsonInclude(JsonInclude.Include.NON_NULL)
-    int lastSelectedGroupIndex,
+    Integer lastSelectedGroupIndex,
     List<JoiningChallengeGroupDto> joiningChallengeGroups
 ) {}

--- a/src/main/java/site/dogether/challengegroup/entity/LastSelectedChallengeGroupRecord.java
+++ b/src/main/java/site/dogether/challengegroup/entity/LastSelectedChallengeGroupRecord.java
@@ -49,4 +49,8 @@ public class LastSelectedChallengeGroupRecord extends BaseEntity {
     public void updateChallengeGroup(final ChallengeGroup challengeGroup) {
         this.challengeGroup = challengeGroup;
     }
+
+    public Long getChallengeGroupId() {
+        return challengeGroup.getId();
+    }
 }

--- a/src/main/java/site/dogether/challengegroup/entity/LastSelectedChallengeGroupRecord.java
+++ b/src/main/java/site/dogether/challengegroup/entity/LastSelectedChallengeGroupRecord.java
@@ -1,0 +1,52 @@
+package site.dogether.challengegroup.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import site.dogether.common.audit.entity.BaseEntity;
+import site.dogether.member.entity.Member;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "last_selected_challenge_group_record")
+@Entity
+public class LastSelectedChallengeGroupRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JoinColumn(name = "member_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @JoinColumn(name = "challenge_group_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    private ChallengeGroup challengeGroup;
+
+    public LastSelectedChallengeGroupRecord(final Member member, final ChallengeGroup challengeGroup) {
+        this(null, member, challengeGroup);
+    }
+
+    public LastSelectedChallengeGroupRecord(
+        final Long id,
+        final Member member,
+        final ChallengeGroup challengeGroup
+    ) {
+        this.id = id;
+        this.member = member;
+        this.challengeGroup = challengeGroup;
+    }
+
+    public void updateChallengeGroup(final ChallengeGroup challengeGroup) {
+        this.challengeGroup = challengeGroup;
+    }
+}

--- a/src/main/java/site/dogether/challengegroup/repository/LastSelectedChallengeGroupRecordRepository.java
+++ b/src/main/java/site/dogether/challengegroup/repository/LastSelectedChallengeGroupRecordRepository.java
@@ -1,0 +1,12 @@
+package site.dogether.challengegroup.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import site.dogether.challengegroup.entity.LastSelectedChallengeGroupRecord;
+import site.dogether.member.entity.Member;
+
+import java.util.Optional;
+
+public interface LastSelectedChallengeGroupRecordRepository extends JpaRepository<LastSelectedChallengeGroupRecord, Long> {
+
+    Optional<LastSelectedChallengeGroupRecord> findByMember(Member member);
+}

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupsWithLastSelectedGroupIndexDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupsWithLastSelectedGroupIndexDto.java
@@ -3,6 +3,6 @@ package site.dogether.challengegroup.service.dto;
 import java.util.List;
 
 public record JoiningChallengeGroupsWithLastSelectedGroupIndexDto(
-    int lastSelectedGroupIndex,
+    Integer lastSelectedGroupIndex,
     List<JoiningChallengeGroupDto> joiningChallengeGroups
 ) {}

--- a/src/main/java/site/dogether/dailytodo/controller/response/GetMyDailyTodosResponse.java
+++ b/src/main/java/site/dogether/dailytodo/controller/response/GetMyDailyTodosResponse.java
@@ -36,7 +36,7 @@ record Data(
             dailyTodo.getDailyTodoStatus(),
             dailyTodo.findDailyTodoCertificationContent().orElse(null),
             dailyTodo.findDailyTodoCertificationMediaUrl().orElse(null),
-            dailyTodo.findRejectReason().orElse(null)
+            dailyTodo.findReviewFeedback().orElse(null)
         );
     }
 }

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -40,7 +40,7 @@ import static site.dogether.dailytodo.entity.DailyTodoStatus.*;
 public class DailyTodo extends BaseEntity {
 
     public static final int MAXIMUM_ALLOWED_CONTENT_LENGTH = 20;
-    public static final int MAXIMUM_ALLOWED_REJECT_REASON_LENGTH = 60;
+    public static final int MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH = 60;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -61,8 +61,8 @@ public class DailyTodo extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private DailyTodoStatus status;
 
-    @Column(name = "reject_reason", length = 500)
-    private String rejectReason;
+    @Column(name = "review_feedback", length = 500)
+    private String reviewFeedback;
 
     @Column(name = "written_at", nullable = false, updatable = false)
     private LocalDateTime writtenAt;
@@ -89,14 +89,14 @@ public class DailyTodo extends BaseEntity {
         final Member member,
         final String content,
         final DailyTodoStatus status,
-        final String rejectReason,
+        final String reviewFeedback,
         final LocalDateTime writtenAt
     ) {
         validateChallengeGroup(challengeGroup);
         validateMember(member);
         validateContent(content);
         validateStatus(status);
-        validateRejectReason(status, rejectReason);
+        validateReviewFeedback(status, reviewFeedback);
         validateWrittenAt(writtenAt);
 
         this.id = id;
@@ -104,7 +104,7 @@ public class DailyTodo extends BaseEntity {
         this.member = member;
         this.content = content;
         this.status = status;
-        this.rejectReason = rejectReason;
+        this.reviewFeedback = reviewFeedback;
         this.writtenAt = writtenAt;
     }
 
@@ -136,13 +136,13 @@ public class DailyTodo extends BaseEntity {
         }
     }
 
-    private void validateRejectReason(final DailyTodoStatus status, final String rejectReason) {
-        if (status == REJECT && (rejectReason == null || rejectReason.isBlank())) {
-            throw new InvalidDailyTodoException(String.format("노인정 사유로 null 혹은 공백을 입력할 수 없습니다. (%s)", rejectReason));
+    private void validateReviewFeedback(final DailyTodoStatus status, final String reviewFeedback) {
+        if (status.isReviewResultStatus() && (reviewFeedback == null || reviewFeedback.isBlank())) {
+            throw new InvalidDailyTodoException(String.format("검사 피드백으로 null 혹은 공백을 입력할 수 없습니다. (%s)", reviewFeedback));
         }
 
-        if (status == REJECT && rejectReason.length() > MAXIMUM_ALLOWED_REJECT_REASON_LENGTH) {
-            throw new InvalidDailyTodoException(String.format("노인정 사유는 %d자 이하만 입력할 수 있습니다. (%d) (%s)", MAXIMUM_ALLOWED_REJECT_REASON_LENGTH, rejectReason.length(), rejectReason));
+        if (status.isReviewResultStatus() && reviewFeedback.length() > MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH) {
+            throw new InvalidDailyTodoException(String.format("검사 피드백은 %d자 이하만 입력할 수 있습니다. (%d) (%s)", MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH, reviewFeedback.length(), reviewFeedback));
         }
     }
 
@@ -202,16 +202,16 @@ public class DailyTodo extends BaseEntity {
             final Member reviewer,
             final DailyTodoCertification dailyTodoCertification,
             final DailyTodoStatus reviewResult,
-            final String rejectReason,
+            final String reviewFeedback,
             final DailyTodoStats dailyTodoStats
             ) {
         validateReviewer(reviewer, dailyTodoCertification);
         validateStatusIsReviewPending();
         validateReviewResult(reviewResult);
-        validateRejectReason(reviewResult, rejectReason);
+        validateReviewFeedback(reviewResult, reviewFeedback);
 
         this.status = reviewResult;
-        this.rejectReason = rejectReason;
+        this.reviewFeedback = reviewFeedback;
 
         dailyTodoStats.moveCertificatedToResult(reviewResult);
     }
@@ -262,8 +262,8 @@ public class DailyTodo extends BaseEntity {
         return status;
     }
 
-    public Optional<String> getRejectReason() {
-        return Optional.ofNullable(rejectReason);
+    public Optional<String> getReviewFeedback() {
+        return Optional.ofNullable(reviewFeedback);
     }
 
     public String getStatusDescription() {

--- a/src/main/java/site/dogether/dailytodo/service/dto/DailyTodoAndDailyTodoCertificationDto.java
+++ b/src/main/java/site/dogether/dailytodo/service/dto/DailyTodoAndDailyTodoCertificationDto.java
@@ -51,11 +51,11 @@ public class DailyTodoAndDailyTodoCertificationDto {
         return Optional.of(dailyTodoCertification.getMediaUrl());
     }
 
-    public Optional<String> findRejectReason() {
+    public Optional<String> findReviewFeedback() {
         if (dailyTodoCertification == null || !dailyTodo.getStatus().isReviewResultStatus()) {
             return Optional.empty();
         }
 
-        return dailyTodo.getRejectReason();
+        return dailyTodo.getReviewFeedback();
     }
 }

--- a/src/main/java/site/dogether/dailytodocertification/exception/InvalidDailyTodoRejectReasonException.java
+++ b/src/main/java/site/dogether/dailytodocertification/exception/InvalidDailyTodoRejectReasonException.java
@@ -1,8 +1,0 @@
-package site.dogether.dailytodocertification.exception;
-
-public class InvalidDailyTodoRejectReasonException extends RuntimeException {
-
-    public InvalidDailyTodoRejectReasonException(final String message) {
-        super(message);
-    }
-}

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -265,7 +265,7 @@ public class MemberActivityService {
                 todo.getStatus().name(),
                 certification.getContent(),
                 certification.getMediaUrl(),
-                todo.getRejectReason().orElse(null)
+                todo.getReviewFeedback().orElse(null)
         );
     }
 

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static site.dogether.dailytodo.entity.DailyTodo.MAXIMUM_ALLOWED_CONTENT_LENGTH;
-import static site.dogether.dailytodo.entity.DailyTodo.MAXIMUM_ALLOWED_REJECT_REASON_LENGTH;
+import static site.dogether.dailytodo.entity.DailyTodo.MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH;
 import static site.dogether.dailytodo.entity.DailyTodoStatus.*;
 
 class DailyTodoTest {
@@ -69,7 +69,7 @@ class DailyTodoTest {
         final ChallengeGroup challengeGroup,
         final Member member,
         final DailyTodoStatus status,
-        final String rejectReason,
+        final String reviewFeedback,
         final LocalDateTime writtenAt
         ) {
         return new DailyTodo(
@@ -78,7 +78,7 @@ class DailyTodoTest {
             member,
             "치킨 먹기",
             status,
-            rejectReason,
+            reviewFeedback,
             writtenAt
         );
     }
@@ -115,7 +115,7 @@ class DailyTodoTest {
         final Member member = createMember();
         final String content = "치킨 먹기";
         final DailyTodoStatus status = REJECT;
-        final String rejectReason = "그딴게 치킨?";
+        final String reviewFeedback = "그딴게 치킨?";
         final LocalDateTime writtenAt = LocalDateTime.now();
 
         // When && Then
@@ -125,7 +125,7 @@ class DailyTodoTest {
             member,
             content,
             status,
-            rejectReason,
+            reviewFeedback,
             writtenAt))
             .doesNotThrowAnyException();
     }
@@ -145,7 +145,7 @@ class DailyTodoTest {
         assertSoftly(softly -> {
             assertThat(created.getId()).isNull();
             assertThat(created.getStatus()).isEqualTo(CERTIFY_PENDING);
-            assertThat(created.getRejectReason()).isEmpty();
+            assertThat(created.getReviewFeedback()).isEmpty();
         });
     }
 
@@ -210,11 +210,11 @@ class DailyTodoTest {
         final ChallengeGroup challengeGroup = createChallengeGroup();
         final Member member = createMember();
         final String content = "치킨 먹기";
-        final String rejectReason = "그딴게 치킨?";
+        final String reviewFeedback = "그딴게 치킨?";
         final LocalDateTime writtenAt = LocalDateTime.now();
 
         // When & Then
-        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, null, rejectReason, writtenAt))
+        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, null, reviewFeedback, writtenAt))
             .isInstanceOf(InvalidDailyTodoException.class)
             .hasMessage("데일리 투두 상태로 null을 입력할 수 없습니다.");
     }
@@ -222,7 +222,7 @@ class DailyTodoTest {
     @DisplayName("데일리 투두가 노인정 상태일 때 노인정 사유로 null 혹은 공백이 입력되면 예외가 발생한다.")
     @NullAndEmptySource
     @ParameterizedTest()
-    void throwExceptionWhenStatusRejectAndInputRejectReasonNullOrEmpty(final String rejectReason) {
+    void throwExceptionWhenStatusRejectAndInputReviewFeedbackNullOrEmpty(final String reviewFeedback) {
         // Given
         final ChallengeGroup challengeGroup = createChallengeGroup();
         final Member member = createMember();
@@ -230,25 +230,25 @@ class DailyTodoTest {
         final LocalDateTime writtenAt = LocalDateTime.now();
 
         // When & Then
-        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, REJECT, rejectReason, writtenAt))
+        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, REJECT, reviewFeedback, writtenAt))
             .isInstanceOf(InvalidDailyTodoException.class)
-            .hasMessage(String.format("노인정 사유로 null 혹은 공백을 입력할 수 없습니다. (%s)", rejectReason));
+            .hasMessage(String.format("검사 피드백으로 null 혹은 공백을 입력할 수 없습니다. (%s)", reviewFeedback));
     }
 
     @DisplayName("데일리 투두가 노인정 상태일 때 유효하지 않은 길이의 노인정 사유가 입력되면 예외가 발생한다.")
     @Test()
-    void throwExceptionWhenStatusRejectAndInputInvalidLengthRejectReason() {
+    void throwExceptionWhenStatusRejectAndInputInvalidLengthReviewFeedback() {
         // Given
         final ChallengeGroup challengeGroup = createChallengeGroup();
         final Member member = createMember();
         final String content = "치킨 먹기";
-        final String rejectReason = "A".repeat(MAXIMUM_ALLOWED_REJECT_REASON_LENGTH + 1);
+        final String reviewFeedback = "A".repeat(MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH + 1);
         final LocalDateTime writtenAt = LocalDateTime.now();
 
         // When & Then
-        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, REJECT, rejectReason, writtenAt))
+        assertThatThrownBy(() -> new DailyTodo(1L, challengeGroup, member, content, REJECT, reviewFeedback, writtenAt))
             .isInstanceOf(InvalidDailyTodoException.class)
-            .hasMessage(String.format("노인정 사유는 %d자 이하만 입력할 수 있습니다. (%d) (%s)", MAXIMUM_ALLOWED_REJECT_REASON_LENGTH, rejectReason.length(), rejectReason));
+            .hasMessage(String.format("검사 피드백은 %d자 이하만 입력할 수 있습니다. (%d) (%s)", MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH, reviewFeedback.length(), reviewFeedback));
     }
 
     @DisplayName("생성자에 데일리 투두 작성일로 null을 입력하면 예외가 발생한다.")
@@ -286,15 +286,15 @@ class DailyTodoTest {
     }
 
     @DisplayName("데일리 투두 상태가 인증 대기중이 아니면 false를 반환한다.")
-    @MethodSource("dailyTodoStatusAndRejectReasonIgnoreCertifyPendingStatus")
+    @MethodSource("dailyTodoStatusAndReviewFeedbackIgnoreCertifyPendingStatus")
     @ParameterizedTest
-    void returnFalseWhenStatusIsNotCertifyPending(final DailyTodoStatus status, final String rejectReason) {
+    void returnFalseWhenStatusIsNotCertifyPending(final DailyTodoStatus status, final String reviewFeedback) {
         // Given
         final DailyTodo dailyTodo = createDailyTodo(
             createChallengeGroup(),
             createMember(),
             status,
-            rejectReason,
+            reviewFeedback,
             LocalDateTime.now()
         );
 
@@ -305,10 +305,10 @@ class DailyTodoTest {
         assertThat(isCertifyPending).isFalse();
     }
 
-    private static Stream<Arguments> dailyTodoStatusAndRejectReasonIgnoreCertifyPendingStatus() {
+    private static Stream<Arguments> dailyTodoStatusAndReviewFeedbackIgnoreCertifyPendingStatus() {
         return Stream.of(
             Arguments.of(REVIEW_PENDING, null),
-            Arguments.of(APPROVE, null),
+            Arguments.of(APPROVE, "우왕!"),
             Arguments.of(REJECT, "노인정!")
         );
     }
@@ -368,9 +368,9 @@ class DailyTodoTest {
     }
 
     @DisplayName("인증 대기 상태가 아닌 투두를 인증 하려고 하면 예외가 발생한다.")
-    @MethodSource("dailyTodoStatusAndRejectReasonIgnoreCertifyPendingStatus")
+    @MethodSource("dailyTodoStatusAndReviewFeedbackIgnoreCertifyPendingStatus")
     @ParameterizedTest
-    void throwExceptionWhenCertifyNotCertifyPendingStatus(final DailyTodoStatus status, final String rejectReason) {
+    void throwExceptionWhenCertifyNotCertifyPendingStatus(final DailyTodoStatus status, final String reviewFeedback) {
         // Given
         final ChallengeGroup challengeGroup = createChallengeGroup();
         final Member writer = createMember(1L, "투두 작성자");
@@ -378,7 +378,7 @@ class DailyTodoTest {
             challengeGroup,
             writer,
             status,
-            rejectReason,
+            reviewFeedback,
             LocalDateTime.now()
         );
         final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
@@ -418,7 +418,7 @@ class DailyTodoTest {
             .hasMessage(String.format("데일리 투두가 작성된 당일에만 투두 인증을 생성할 수 있습니다. (%s)", dailyTodo));
     }
 
-    @DisplayName("인정에 대해 유효한 검사 값(검사자, 투두 인증, 검사 결과, 노인정 사유)을 입력하면 투두 상태를 인정으로 변경하고 노인정 사유는 조회시 Optional.empty()를 반환한다.")
+    @DisplayName("인정에 대해 유효한 검사 값(검사자, 투두 인증, 검사 결과, 피드백)을 입력하면 투두 상태를 인정으로 변경하고 노인정 사유는 조회시 Optional.empty()를 반환한다.")
     @Test
     void reviewSuccessInputApprove() {
         // Given
@@ -430,15 +430,15 @@ class DailyTodoTest {
         final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = APPROVE;
-        final String rejectReason = null;
+        final String reviewFeedback = "우왕 쩐당";
 
         // When
-        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats);
+        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, reviewFeedback, dailyTodoStats);
 
         // Then
         assertSoftly(softly -> {
             softly.assertThat(dailyTodo.getStatus()).isEqualTo(APPROVE);
-            softly.assertThat(dailyTodo.getRejectReason()).isEmpty();
+            softly.assertThat(dailyTodo.getReviewFeedback().get()).isEqualTo(reviewFeedback);
         });
     }
 
@@ -454,16 +454,16 @@ class DailyTodoTest {
         final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = REJECT;
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         // When
-        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats);
+        dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, reviewFeedback, dailyTodoStats);
 
         // Then
         assertSoftly(softly -> {
             softly.assertThat(dailyTodo.getStatus()).isEqualTo(REJECT);
-            softly.assertThat(dailyTodo.getRejectReason()).isNotEmpty();
-            softly.assertThat(dailyTodo.getRejectReason().get()).isEqualTo(rejectReason);
+            softly.assertThat(dailyTodo.getReviewFeedback()).isNotEmpty();
+            softly.assertThat(dailyTodo.getReviewFeedback().get()).isEqualTo(reviewFeedback);
         });
     }
 
@@ -479,12 +479,12 @@ class DailyTodoTest {
         final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = REJECT;
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         final Member otherMember = createMember(3L, "이상한 사람");
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.review(otherMember, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats))
+        assertThatThrownBy(() -> dailyTodo.review(otherMember, dailyTodoCertification, reviewResult, reviewFeedback, dailyTodoStats))
             .isInstanceOf(NotDailyTodoCertificationReviewerException.class)
             .hasMessage(String.format("해당 투두 인증 검사자 외 멤버는 검사를 수행할 수 없습니다. (%s) (%s)", otherMember, dailyTodoCertification));
     }
@@ -495,16 +495,16 @@ class DailyTodoTest {
         // Given
         final ChallengeGroup challengeGroup = createChallengeGroup();
         final Member writer = createMember(1L, "투두 작성자");
-        final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, APPROVE, null, LocalDateTime.now().minusHours(2));
+        final DailyTodo dailyTodo = createDailyTodo(challengeGroup, writer, APPROVE, "우왕 쩐당", LocalDateTime.now().minusHours(2));
         final Member reviewer = createMember(2L, "인증 검사자");
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
         final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
         final DailyTodoStatus reviewResult = REJECT;
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats))
+        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, reviewFeedback, dailyTodoStats))
             .isInstanceOf(NotReviewPendingDailyTodoException.class)
             .hasMessage(String.format("검사 대기가 아닌 투두는 검사를 수행할 수 없습니다. (%s)", dailyTodo));
     }
@@ -521,10 +521,10 @@ class DailyTodoTest {
         final DailyTodoCertification dailyTodoCertification = createDailyTodoCertification(dailyTodo, reviewer);
         final DailyTodoStats dailyTodoStats = createDailyTodoStats(writer);
 
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         // When & Then
-        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, rejectReason, dailyTodoStats))
+        assertThatThrownBy(() -> dailyTodo.review(reviewer, dailyTodoCertification, reviewResult, reviewFeedback, dailyTodoStats))
             .isInstanceOf(InvalidReviewResultException.class)
             .hasMessage(String.format("검사 결과는 인정 혹은 노인정만 입력할 수 있습니다. (%s) (%s)", reviewResult, dailyTodo));
     }

--- a/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
+++ b/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
@@ -101,7 +101,7 @@ class DailyTodoServiceTest {
         final ChallengeGroup challengeGroup,
         final Member member,
         final DailyTodoStatus status,
-        final String rejectReason,
+        final String reviewFeedback,
         final LocalDateTime writtenAt
     ) {
         return new DailyTodo(
@@ -110,7 +110,7 @@ class DailyTodoServiceTest {
             member,
             "치킨 먹기",
             status,
-            rejectReason,
+            reviewFeedback,
             writtenAt
         );
     }

--- a/src/test/java/site/dogether/dailytodocertification/entity/DailyTodoCertificationTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/entity/DailyTodoCertificationTest.java
@@ -46,7 +46,7 @@ class DailyTodoCertificationTest {
         final ChallengeGroup challengeGroup,
         final Member member,
         final DailyTodoStatus status,
-        final String rejectReason,
+        final String reviewFeedback,
         final LocalDateTime writtenAt
     ) {
         return new DailyTodo(
@@ -55,7 +55,7 @@ class DailyTodoCertificationTest {
             member,
             "치킨 먹기",
             status,
-            rejectReason,
+            reviewFeedback,
             writtenAt
         );
     }

--- a/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
@@ -65,7 +65,7 @@ class DailyTodoCertificationServiceTest {
         final ChallengeGroup challengeGroup,
         final Member member,
         final DailyTodoStatus status,
-        final String rejectReason,
+        final String reviewFeedback,
         final LocalDateTime writtenAt
     ) {
         return new DailyTodo(
@@ -74,7 +74,7 @@ class DailyTodoCertificationServiceTest {
             member,
             "치킨 먹기",
             status,
-            rejectReason,
+            reviewFeedback,
             writtenAt
         );
     }
@@ -103,7 +103,7 @@ class DailyTodoCertificationServiceTest {
         );
     }
     
-    @DisplayName("인정에 대해 유효한 검사 값(검사자 id, 투두 인증 id, 검사 결과, 노인정 사유)을 넘기면 투두 인증 검사를 수행하고 변경된 부분을 DB에 반영 요청 한다.")
+    @DisplayName("인정에 대해 유효한 검사 값(검사자 id, 투두 인증 id, 검사 결과, 피드백)을 넘기면 투두 인증 검사를 수행하고 변경된 부분을 DB에 반영 요청 한다.")
     @Test
     void reviewDailyTodoCertificationSuccessInputApprove() {
         // Given
@@ -117,14 +117,14 @@ class DailyTodoCertificationServiceTest {
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();
         final String reviewResult = "approve";
-        final String rejectReason = null;
+        final String reviewFeedback = "우왕!";
 
         // When & Then
         assertThatCode(() -> dailyTodoCertificationService.reviewDailyTodoCertification(
             reviewerId,
             dailyTodoCertificationId,
             reviewResult,
-            rejectReason))
+            reviewFeedback))
             .doesNotThrowAnyException();
     }
 
@@ -142,14 +142,14 @@ class DailyTodoCertificationServiceTest {
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();
         final String reviewResult = "reject";
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         // When & Then
         assertThatCode(() -> dailyTodoCertificationService.reviewDailyTodoCertification(
             reviewerId,
             dailyTodoCertificationId,
             reviewResult,
-            rejectReason))
+            reviewFeedback))
             .doesNotThrowAnyException();
     }
 
@@ -166,14 +166,14 @@ class DailyTodoCertificationServiceTest {
         final Long reviewerId = 1232L;
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();
         final String reviewResult = "reject";
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         // When & Then
         assertThatThrownBy(() -> dailyTodoCertificationService.reviewDailyTodoCertification(
             reviewerId,
             dailyTodoCertificationId,
             reviewResult,
-            rejectReason
+            reviewFeedback
         ))
             .isInstanceOf(MemberNotFoundException.class)
             .hasMessage(String.format("존재하지 않는 회원 id입니다. (%d)", reviewerId));
@@ -192,14 +192,14 @@ class DailyTodoCertificationServiceTest {
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = 1231231L;
         final String reviewResult = "reject";
-        final String rejectReason = "이게 최선이야?";
+        final String reviewFeedback = "이게 최선이야?";
 
         // When & Then
         assertThatThrownBy(() -> dailyTodoCertificationService.reviewDailyTodoCertification(
             reviewerId,
             dailyTodoCertificationId,
             reviewResult,
-            rejectReason
+            reviewFeedback
         ))
             .isInstanceOf(DailyTodoCertificationNotFoundException.class)
             .hasMessage(String.format("존재하지 않는 데일리 투두 인증 id입니다. (%d)", dailyTodoCertificationId));


### PR DESCRIPTION
투두 인증 검사 피드백 & 사용자가 가장 마지막에 선택한 그룹의 정보 저장 기능을 구현하였습니다. 마지막 선택 그룹 기능은 무언가 예외 상황이 발생할 때 에러를 보내는것 보다는 첫 번째 그룹 인덱스를 저장하고 보내는게 안정적이라 생각해 이 방식으로 구현하였습니다.

배포는 해당 PR 머지시 바로 진행하지 않고 테이블이 변경되는 다른 작업을 끝낸 후 함께 일괄 배포하겠습니다.

This closes #118 