### PR TITLE
투두 히스토리 저장 & 조회 방식 개선 및 오늘보다 과거 날짜 투두의 히스토리가 보이는 문제 해결

### DIFF
--- a/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
+++ b/src/main/java/site/dogether/dailytodo/controller/DailyTodoController.java
@@ -73,7 +73,7 @@ public class DailyTodoController {
         @PathVariable final Long groupId,
         @PathVariable final Long targetMemberId
     ) {
-        final FindTargetMemberTodayTodoHistoriesDto targetMemberTodayTodoHistories = dailyTodoHistoryService.findTargetMemberTodayTodoHistories(memberId, groupId, targetMemberId);
+        final FindTargetMemberTodayTodoHistoriesDto targetMemberTodayTodoHistories = dailyTodoHistoryService.findAllTodayTodoHistories(memberId, groupId, targetMemberId);
         final GetChallengeGroupMemberTodayTodoHistoryResponse response = GetChallengeGroupMemberTodayTodoHistoryResponse.from(targetMemberTodayTodoHistories);
         return ResponseEntity.ok(ApiResponse.successWithData(GET_CHALLENGE_GROUP_MEMBER_TODAY_TODO_HISTORY, response));
     }

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -281,4 +281,8 @@ public class DailyTodo extends BaseEntity {
     public String getMemberName() {
         return member.getName();
     }
+
+    public LocalDateTime getWrittenAt() {
+        return writtenAt;
+    }
 }

--- a/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
+++ b/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
@@ -69,7 +69,7 @@ public class DailyTodoService {
         final DailyTodos dailyTodos = createDailyTodos(challengeGroup, member, dailyTodoContents);
         final List<DailyTodo> savedDailyTodos = dailyTodoRepository.saveAll(dailyTodos.getValues());
 
-        dailyTodoHistoryService.saveDailyTodoHistories(savedDailyTodos);
+        dailyTodoHistoryService.initDailyTodoHistories(savedDailyTodos);
     }
 
     private Member getMember(final Long memberId) {
@@ -140,7 +140,7 @@ public class DailyTodoService {
         final DailyTodoCertification dailyTodoCertification = dailyTodo.certify(writer, reviewer, certifyContent, certifyMediaUrl, dailyTodoStats);
         dailyTodoCertificationRepository.save(dailyTodoCertification);
 
-        dailyTodoHistoryService.saveDailyTodoHistory(dailyTodo, dailyTodoCertification);
+        dailyTodoHistoryService.updateDailyTodoHistory(dailyTodo);
         sendNotificationToReviewer(reviewer, writer, dailyTodo);
     }
 

--- a/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
+++ b/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
@@ -50,7 +50,7 @@ public class DailyTodoCertificationService {
 
         dailyTodo.review(reviewer, dailyTodoCertification, DailyTodoStatus.convertFromValue(reviewResult), reviewFeedback, dailyTodoStats);
 
-        dailyTodoHistoryService.saveDailyTodoHistory(dailyTodo, dailyTodoCertification);
+        dailyTodoHistoryService.updateDailyTodoHistory(dailyTodo);
         sendReviewResultNotificationToDailyTodoWriter(dailyTodo);
     }
 

--- a/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistory.java
+++ b/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistory.java
@@ -2,23 +2,19 @@ package site.dogether.dailytodohistory.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.common.audit.entity.BaseEntity;
-import site.dogether.dailytodo.entity.DailyTodoStatus;
-import site.dogether.member.entity.Member;
+import site.dogether.dailytodo.entity.DailyTodo;
 
 import java.time.LocalDateTime;
 
@@ -33,67 +29,28 @@ public class DailyTodoHistory extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @JoinColumn(name = "challenge_group_id", nullable = false, updatable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private ChallengeGroup challengeGroup;
+    @JoinColumn(name = "daily_todo_id", nullable = false)
+    @OneToOne(fetch = FetchType.LAZY)
+    private DailyTodo dailyTodo;
 
-    @JoinColumn(name = "member_id", nullable = false, updatable = false)
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Member member;
+    @Column(name = "event_time", nullable = false)
+    private LocalDateTime eventTime;
 
-    @Column(name = "todo_content", length = 30, nullable = false, updatable = false)
-    private String todoContent;
-
-    @Column(name = "todo_status", length = 20, nullable = false, updatable = false)
-    @Enumerated(EnumType.STRING)
-    private DailyTodoStatus todoStatus;
-
-    @Column(name = "todo_certification_content", length = 200, updatable = false)
-    private String todoCertificationContent;
-
-    @Column(name = "todo_certification_media_url", length = 500, updatable = false)
-    private String todoCertificationMediaUrl;
-
-    @Column(name = "event_at", nullable = false, updatable = false)
-    private LocalDateTime eventAt;
-
-    public DailyTodoHistory(
-        final ChallengeGroup challengeGroup,
-        final Member member,
-        final String todoContent,
-        final DailyTodoStatus todoStatus,
-        final String todoCertificationContent,
-        final String todoCertificationMediaUrl
-    ) {
-        this(
-            null,
-            challengeGroup,
-            member,
-            todoContent,
-            todoStatus,
-            todoCertificationContent,
-            todoCertificationMediaUrl,
-            LocalDateTime.now()
-        );
+    public DailyTodoHistory(final DailyTodo dailyTodo) {
+        this(null, dailyTodo, LocalDateTime.now());
     }
 
     public DailyTodoHistory(
         final Long id,
-        final ChallengeGroup challengeGroup,
-        final Member member,
-        final String todoContent,
-        final DailyTodoStatus todoStatus,
-        final String todoCertificationContent,
-        final String todoCertificationMediaUrl,
-        final LocalDateTime eventAt
+        final DailyTodo dailyTodo,
+        final LocalDateTime eventTime
     ) {
         this.id = id;
-        this.challengeGroup = challengeGroup;
-        this.member = member;
-        this.todoContent = todoContent;
-        this.todoStatus = todoStatus;
-        this.todoCertificationContent = todoCertificationContent;
-        this.todoCertificationMediaUrl = todoCertificationMediaUrl;
-        this.eventAt = eventAt;
+        this.dailyTodo = dailyTodo;
+        this.eventTime = eventTime;
+    }
+
+    public void updateEventTime() {
+        this.eventTime = LocalDateTime.now();
     }
 }

--- a/src/main/java/site/dogether/dailytodohistory/repository/DailyTodoHistoryReadRepository.java
+++ b/src/main/java/site/dogether/dailytodohistory/repository/DailyTodoHistoryReadRepository.java
@@ -8,4 +8,6 @@ import site.dogether.member.entity.Member;
 public interface DailyTodoHistoryReadRepository extends JpaRepository<DailyTodoHistoryRead, Long> {
 
     boolean existsByMemberAndDailyTodoHistory(Member member, DailyTodoHistory dailyTodoHistory);
+
+    void deleteAllByDailyTodoHistory(DailyTodoHistory dailyTodoHistory);
 }

--- a/src/main/java/site/dogether/dailytodohistory/repository/DailyTodoHistoryRepository.java
+++ b/src/main/java/site/dogether/dailytodohistory/repository/DailyTodoHistoryRepository.java
@@ -2,15 +2,19 @@ package site.dogether.dailytodohistory.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.dogether.challengegroup.entity.ChallengeGroup;
+import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodohistory.entity.DailyTodoHistory;
 import site.dogether.member.entity.Member;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface DailyTodoHistoryRepository extends JpaRepository<DailyTodoHistory, Long> {
 
-    List<DailyTodoHistory> findAllByChallengeGroupAndMemberAndEventAtBetween(
+    Optional<DailyTodoHistory> findByDailyTodo(DailyTodo dailyTodo);
+
+    List<DailyTodoHistory> findAllByDailyTodo_ChallengeGroupAndDailyTodo_MemberAndDailyTodo_WrittenAtBetweenOrderByEventTimeAsc(
         ChallengeGroup challengeGroup,
         Member member,
         LocalDateTime start,

--- a/src/main/java/site/dogether/dailytodohistory/service/dto/TodoHistoryDto.java
+++ b/src/main/java/site/dogether/dailytodohistory/service/dto/TodoHistoryDto.java
@@ -1,7 +1,6 @@
 package site.dogether.dailytodohistory.service.dto;
 
 import site.dogether.dailytodo.entity.DailyTodoStatus;
-import site.dogether.dailytodohistory.entity.DailyTodoHistory;
 
 public record TodoHistoryDto(
     Long id,
@@ -10,15 +9,4 @@ public record TodoHistoryDto(
     String certificationContent,
     String certificationMediaUrl,
     boolean isRead
-) {
-    public static TodoHistoryDto fromTodoHistory(final DailyTodoHistory dailyTodoHistory, final boolean isHistoryRead) {
-        return new TodoHistoryDto(
-            dailyTodoHistory.getId(),
-            dailyTodoHistory.getTodoContent(),
-            dailyTodoHistory.getTodoStatus(),
-            dailyTodoHistory.getTodoCertificationContent(),
-            dailyTodoHistory.getTodoCertificationMediaUrl(),
-            isHistoryRead
-        );
-    }
-}
+) {}

--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -16,7 +16,6 @@ import site.dogether.challengegroup.entity.ChallengeGroupMember;
 import site.dogether.common.audit.entity.BaseEntity;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
-import site.dogether.dailytodohistory.entity.DailyTodoHistory;
 import site.dogether.dailytodohistory.entity.DailyTodoHistoryRead;
 import site.dogether.member.exception.InvalidMemberException;
 import site.dogether.memberactivity.entity.DailyTodoStats;
@@ -60,8 +59,9 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<DailyTodo> dailyTodos;
 
-    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-    private List<DailyTodoHistory> dailyTodoHistory;
+    // TODO : 대안책이 없는지 영재님이랑 논의
+//    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+//    private List<DailyTodoHistory> dailyTodoHistory;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<DailyTodoHistoryRead> dailyTodoHistoryRead;

--- a/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
+++ b/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
@@ -20,6 +20,8 @@ import site.dogether.dailytodo.entity.DailyTodoStatus;
 import site.dogether.dailytodo.exception.DailyTodoAlreadyCreatedException;
 import site.dogether.dailytodo.exception.DailyTodoNotFoundException;
 import site.dogether.dailytodo.repository.DailyTodoRepository;
+import site.dogether.dailytodohistory.entity.DailyTodoHistory;
+import site.dogether.dailytodohistory.repository.DailyTodoHistoryRepository;
 import site.dogether.fake.FakeRandomGenerator;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
@@ -44,6 +46,7 @@ class DailyTodoServiceTest {
     @Autowired private ChallengeGroupMemberRepository challengeGroupMemberRepository;
     @Autowired private DailyTodoRepository dailyTodoRepository;
     @Autowired private DailyTodoStatsRepository dailyTodoStatsRepository;
+    @Autowired private DailyTodoHistoryRepository dailyTodoHistoryRepository;
     @Autowired private DailyTodoService dailyTodoService;
     @Autowired private FakeRandomGenerator randomGenerator;
 
@@ -123,6 +126,10 @@ class DailyTodoServiceTest {
                 2,
                 3
         );
+    }
+
+    private static DailyTodoHistory createDailyTodoHistory(final DailyTodo dailyTodo) {
+        return new DailyTodoHistory(dailyTodo);
     }
 
     @DisplayName("유효한 값을 입력하면 데일리 투두를 생성 후 저장한다.")
@@ -296,6 +303,7 @@ class DailyTodoServiceTest {
             LocalDateTime.now()
         ));
         dailyTodoStatsRepository.save(createDailyTodoStats(writer));
+        dailyTodoHistoryRepository.save(createDailyTodoHistory(dailyTodo));
 
         final Long writerId = writer.getId();
         final Long dailyTodoId = dailyTodo.getId();
@@ -334,6 +342,7 @@ class DailyTodoServiceTest {
             LocalDateTime.now()
         ));
         dailyTodoStatsRepository.save(createDailyTodoStats(writer));
+        dailyTodoHistoryRepository.save(createDailyTodoHistory(dailyTodo));
 
         randomGenerator.setResult(2); // 검사자로 썬이 선정되도록 조작
 

--- a/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
@@ -14,6 +14,8 @@ import site.dogether.dailytodo.repository.DailyTodoRepository;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodocertification.exception.DailyTodoCertificationNotFoundException;
 import site.dogether.dailytodocertification.repository.DailyTodoCertificationRepository;
+import site.dogether.dailytodohistory.entity.DailyTodoHistory;
+import site.dogether.dailytodohistory.repository.DailyTodoHistoryRepository;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
@@ -36,6 +38,7 @@ class DailyTodoCertificationServiceTest {
     @Autowired private DailyTodoRepository dailyTodoRepository;
     @Autowired private DailyTodoCertificationRepository dailyTodoCertificationRepository;
     @Autowired private DailyTodoStatsRepository dailyTodoStatsRepository;
+    @Autowired private DailyTodoHistoryRepository dailyTodoHistoryRepository;
     @Autowired private DailyTodoCertificationService dailyTodoCertificationService;
 
     private static ChallengeGroup createChallengeGroup() {
@@ -102,6 +105,10 @@ class DailyTodoCertificationServiceTest {
                 3
         );
     }
+
+    private static DailyTodoHistory createDailyTodoHistory(final DailyTodo dailyTodo) {
+        return new DailyTodoHistory(dailyTodo);
+    }
     
     @DisplayName("인정에 대해 유효한 검사 값(검사자 id, 투두 인증 id, 검사 결과, 피드백)을 넘기면 투두 인증 검사를 수행하고 변경된 부분을 DB에 반영 요청 한다.")
     @Test
@@ -113,6 +120,7 @@ class DailyTodoCertificationServiceTest {
         final Member reviewer = memberRepository.save(createMember("인증 검사자"));
         final DailyTodoCertification dailyTodoCertification = dailyTodoCertificationRepository.save(createDailyTodoCertification(dailyTodo, reviewer));
         dailyTodoStatsRepository.save(createDailyTodoStats(writer));
+        dailyTodoHistoryRepository.save(createDailyTodoHistory(dailyTodo));
 
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();
@@ -138,6 +146,8 @@ class DailyTodoCertificationServiceTest {
         final Member reviewer = memberRepository.save(createMember("인증 검사자"));
         final DailyTodoCertification dailyTodoCertification = dailyTodoCertificationRepository.save(createDailyTodoCertification(dailyTodo, reviewer));
         dailyTodoStatsRepository.save(createDailyTodoStats(writer));
+        dailyTodoHistoryRepository.save(createDailyTodoHistory(dailyTodo));
+
 
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();

--- a/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
@@ -148,7 +148,6 @@ class DailyTodoCertificationServiceTest {
         dailyTodoStatsRepository.save(createDailyTodoStats(writer));
         dailyTodoHistoryRepository.save(createDailyTodoHistory(dailyTodo));
 
-
         final Long reviewerId = reviewer.getId();
         final Long dailyTodoCertificationId = dailyTodoCertification.getId();
         final String reviewResult = "reject";

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -261,7 +261,7 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                 new TodoHistoryDto(6L, "치킨 먹기", REJECT, "개꿀맛 치킨 냠냠", "https://치킨.png", false)
             )
         );
-        given(dailyTodoHistoryService.findTargetMemberTodayTodoHistories(any(), any(), any()))
+        given(dailyTodoHistoryService.findAllTodayTodoHistories(any(), any(), any()))
             .willReturn(serviceMockResponse);
 
         mockMvc.perform(


### PR DESCRIPTION
투두 히스토리 저장 & 조회 방식을 개선하고 오늘보다 과거 날짜 투두의 히스토리가 보이는 문제를 해결하였습니다.

해당 PR도 바로 배포하지 않고 이후 진행할 오류 조치 완료후 함께 배포하겠습니다.

This closes #108 