### PR TITLE
회원 탈퇴가 작동되지 않는 이슈 해결 & 인정 피드백은 null과 공백이 허용되도록 변경

### DIFF
--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -1,5 +1,6 @@
 package site.dogether.dailytodo.entity;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -10,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -24,6 +26,7 @@ import site.dogether.dailytodo.exception.NotDailyTodoWriterException;
 import site.dogether.dailytodo.exception.NotReviewPendingDailyTodoException;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodocertification.exception.NotDailyTodoCertificationReviewerException;
+import site.dogether.dailytodohistory.entity.DailyTodoHistory;
 import site.dogether.member.entity.Member;
 import site.dogether.memberactivity.entity.DailyTodoStats;
 
@@ -66,6 +69,14 @@ public class DailyTodo extends BaseEntity {
 
     @Column(name = "written_at", nullable = false, updatable = false)
     private LocalDateTime writtenAt;
+
+    @ToString.Exclude
+    @OneToOne(mappedBy = "dailyTodo", cascade = CascadeType.REMOVE)
+    private DailyTodoHistory dailyTodoHistory;
+
+    @ToString.Exclude
+    @OneToOne(mappedBy = "dailyTodo", cascade = CascadeType.REMOVE)
+    private DailyTodoCertification dailyTodoCertification;
 
     public DailyTodo(
         final ChallengeGroup challengeGroup,

--- a/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
+++ b/src/main/java/site/dogether/dailytodo/entity/DailyTodo.java
@@ -136,12 +136,12 @@ public class DailyTodo extends BaseEntity {
         }
     }
 
-    private void validateReviewFeedback(final DailyTodoStatus status, final String reviewFeedback) {
-        if (status.isReviewResultStatus() && (reviewFeedback == null || reviewFeedback.isBlank())) {
+    private void validateReviewFeedback(final DailyTodoStatus reviewResult, final String reviewFeedback) {
+        if (reviewResult == REJECT && (reviewFeedback == null || reviewFeedback.isBlank())) {
             throw new InvalidDailyTodoException(String.format("검사 피드백으로 null 혹은 공백을 입력할 수 없습니다. (%s)", reviewFeedback));
         }
 
-        if (status.isReviewResultStatus() && reviewFeedback.length() > MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH) {
+        if (reviewResult == REJECT && reviewFeedback.length() > MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH) {
             throw new InvalidDailyTodoException(String.format("검사 피드백은 %d자 이하만 입력할 수 있습니다. (%d) (%s)", MAXIMUM_ALLOWED_REVIEW_FEEDBACK_LENGTH, reviewFeedback.length(), reviewFeedback));
         }
     }
@@ -280,9 +280,5 @@ public class DailyTodo extends BaseEntity {
 
     public String getMemberName() {
         return member.getName();
-    }
-
-    public LocalDateTime getWrittenAt() {
-        return writtenAt;
     }
 }

--- a/src/main/java/site/dogether/developer_test/member/DeveloperTestMemberApi.java
+++ b/src/main/java/site/dogether/developer_test/member/DeveloperTestMemberApi.java
@@ -1,0 +1,39 @@
+package site.dogether.developer_test.member;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import site.dogether.auth.service.AuthService;
+import site.dogether.member.entity.Member;
+import site.dogether.member.service.MemberService;
+
+import java.util.Map;
+
+@Profile("local")
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class DeveloperTestMemberApi {
+
+    private final MemberService memberService;
+    private final AuthService authService;
+
+    @PostMapping("/api/dev/save-member")
+    public String saveMember(@RequestBody final Map<String, String> request) {
+        final Member saved = memberService.save(request.get("providerId"), request.get("name"));
+        log.info("member save : {}", saved);
+        return authService.issueTestUserJwt(saved.getId());
+    }
+
+    @DeleteMapping("/api/dev/delete-member/{memberId}")
+    public String deleteMember(@PathVariable final Long memberId) {
+        memberService.delete(memberId);
+        log.info("member delete : {}", memberId);
+        return "탈퇴 완료!! - " + memberId;
+    }
+}

--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -12,7 +12,9 @@ import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import site.dogether.challengegroup.entity.ChallengeGroupMember;
+import site.dogether.challengegroup.entity.LastSelectedChallengeGroupRecord;
 import site.dogether.common.audit.entity.BaseEntity;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
@@ -47,27 +49,33 @@ public class Member extends BaseEntity {
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<NotificationToken> notificationTokens;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<ChallengeGroupMember> challengeGroupMembers;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "reviewer", cascade = CascadeType.REMOVE)
     private List<DailyTodoCertification> dailyTodoCertifications;
 
+    @ToString.Exclude
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<DailyTodo> dailyTodos;
 
-    // TODO : 대안책이 없는지 영재님이랑 논의
-//    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
-//    private List<DailyTodoHistory> dailyTodoHistory;
-
+    @ToString.Exclude
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<DailyTodoHistoryRead> dailyTodoHistoryRead;
 
+    @ToString.Exclude
     @OneToOne(mappedBy = "member", cascade = CascadeType.REMOVE)
     private DailyTodoStats dailyTodoStats;
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<LastSelectedChallengeGroupRecord> lastSelectedChallengeGroupRecords;
 
     public static Member create(final String providerId, final String name) {
         return new Member(null, providerId, name, saveRandomProfileImageUrl(), LocalDateTime.now());


### PR DESCRIPTION
- 회원 탈퇴가 되지 않는 이슈를 해결하고 인정 피드백 입력에 대한 제약 조건을 null or 공백 허용으로 변경하였습니다. 
- 추가로 기존 양방향 매핑 코드는 StackOverFlow를 유발할 수 있는 잠재적 위험이 존재해 이를 방지하는 코드를 추가하였습니다.

그리고 현재는 회원 탈퇴시 관련 데이터를 모두 삭제하는 방식으로 JPA의 cascade 방식을 사용하지만 양방향 매핑을 해야하는 트레이드 오프가 존재하므로 더 나은 방법이 없는지 백엔드 회의를 진행할 필요가 있습니다. (@yeong0jae @Hwangseoeun )

This closes #123 