### PR TITLE
투두 인증 카운트 NPE 문제 해결

### DIFF
--- a/src/main/java/site/dogether/challengegroup/entity/AchievementRateCalculator.java
+++ b/src/main/java/site/dogether/challengegroup/entity/AchievementRateCalculator.java
@@ -22,8 +22,8 @@ public class AchievementRateCalculator {
         }
         // TODO: 추후 해당 로직 리팩토링 필요
         final int totalTodoCount = dailyTodos.size();
-        final int certificatedCount = dailyTodoCertificationCount.totalCount().intValue();
-        final int approvedCount = dailyTodoCertificationCount.approvedCount().intValue();
+        final int certificatedCount = dailyTodoCertificationCount.getTotalCount();
+        final int approvedCount = dailyTodoCertificationCount.getApprovedCount();
 
         final double certificationRate = (double) certificatedCount / totalTodoCount;
         final double approvalRate = (double) approvedCount / certificatedCount;

--- a/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationCount.java
+++ b/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationCount.java
@@ -1,7 +1,35 @@
 package site.dogether.dailytodocertification.repository;
 
-public record DailyTodoCertificationCount(
-    Long totalCount,
-    Long approvedCount,
-    Long rejectedCount
-) {}
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class DailyTodoCertificationCount {
+
+    private final Long totalCount;
+    private final Long approvedCount;
+    private final Long rejectedCount;
+
+    public int getTotalCount() {
+        if (totalCount == null) {
+            return 0;
+        }
+
+        return totalCount.intValue();
+    }
+
+    public int getApprovedCount() {
+        if (approvedCount == null) {
+            return 0;
+        }
+
+        return approvedCount.intValue();
+    }
+
+    public int getRejectedCount() {
+        if (rejectedCount == null) {
+            return 0;
+        }
+
+        return rejectedCount.intValue();
+    }
+}

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -168,9 +168,9 @@ public class MemberActivityService {
         final DailyTodoCertificationCount dailyTodoCertificationCount = dailyTodoCertificationRepository.countDailyTodoCertification(challengeGroup, member);
 
         return new GetGroupActivityStatResponse.MemberStatsResponse(
-            dailyTodoCertificationCount.totalCount().intValue(),
-            dailyTodoCertificationCount.approvedCount().intValue(),
-            dailyTodoCertificationCount.rejectedCount().intValue()
+            dailyTodoCertificationCount.getTotalCount(),
+            dailyTodoCertificationCount.getApprovedCount(),
+            dailyTodoCertificationCount.getRejectedCount()
         );
     }
 


### PR DESCRIPTION
- 데일리 투두 통계 페이지 에러
- 챌린지 그룹 랭킹 페이지 에러

위 에러 모두 투두 인증 카운트 객체의 NPE 문제로 인해 발생하였음을 확인했기에 조치했습니다.