### PR TITLE
[BE] 다른 그룹원의 히스토리에서 피드백을 조회할 수 있는 기능 추가

### DIFF
--- a/src/main/java/site/dogether/dailytodo/controller/response/GetChallengeGroupMemberTodayTodoHistoryResponse.java
+++ b/src/main/java/site/dogether/dailytodo/controller/response/GetChallengeGroupMemberTodayTodoHistoryResponse.java
@@ -1,10 +1,9 @@
 package site.dogether.dailytodo.controller.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.List;
 import site.dogether.dailytodohistory.service.dto.FindTargetMemberTodayTodoHistoriesDto;
 import site.dogether.dailytodohistory.service.dto.TodoHistoryDto;
-
-import java.util.List;
 
 public record GetChallengeGroupMemberTodayTodoHistoryResponse(
     int currentTodoHistoryToReadIndex,
@@ -23,7 +22,9 @@ public record GetChallengeGroupMemberTodayTodoHistoryResponse(
         String certificationContent,
         @JsonInclude(JsonInclude.Include.NON_NULL)
         String certificationMediaUrl,
-        boolean isRead
+        boolean isRead,
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        String reviewFeedback
     ) {
         public static TodoData from(final TodoHistoryDto dto) {
             return new TodoData(
@@ -32,7 +33,8 @@ public record GetChallengeGroupMemberTodayTodoHistoryResponse(
                 dto.status(),
                 dto.certificationContent(),
                 dto.certificationMediaUrl(),
-                dto.isRead()
+                dto.isRead(),
+                dto.reviewFeedback()
             );
         }
     }

--- a/src/main/java/site/dogether/dailytodohistory/service/DailyTodoHistoryService.java
+++ b/src/main/java/site/dogether/dailytodohistory/service/DailyTodoHistoryService.java
@@ -1,5 +1,8 @@
 package site.dogether.dailytodohistory.service;
 
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,10 +23,6 @@ import site.dogether.dailytodohistory.service.dto.TodoHistoryDto;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.util.List;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -99,14 +98,16 @@ public class DailyTodoHistoryService {
                 dailyTodoCertification.getReviewStatus().name(),
                 dailyTodoCertification.getContent(),
                 dailyTodoCertification.getMediaUrl(),
-                isHistoryRead))
+                isHistoryRead,
+                dailyTodoCertification.findReviewFeedback().orElse(null)))
             .orElse(new TodoHistoryDto(
                 history.getId(),
                 dailyTodo.getContent(),
                 dailyTodo.getStatus().name(),
                 null,
                 null,
-                isHistoryRead));
+                isHistoryRead,
+                    null));
     }
 
     private boolean checkMemberReadDailyTodoHistory(final Member member, final DailyTodoHistory dailyTodoHistory) {

--- a/src/main/java/site/dogether/dailytodohistory/service/dto/TodoHistoryDto.java
+++ b/src/main/java/site/dogether/dailytodohistory/service/dto/TodoHistoryDto.java
@@ -6,5 +6,6 @@ public record TodoHistoryDto(
     String status,
     String certificationContent,
     String certificationMediaUrl,
-    boolean isRead
+    boolean isRead,
+    String reviewFeedback
 ) {}

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -1,5 +1,26 @@
 package site.dogether.docs.dailytodo;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_COMPLETED;
+import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_PENDING;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.APPROVE;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.REJECT;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.REVIEW_PENDING;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
@@ -17,22 +38,6 @@ import site.dogether.dailytodohistory.service.dto.FindTargetMemberTodayTodoHisto
 import site.dogether.dailytodohistory.service.dto.TodoHistoryDto;
 import site.dogether.docs.util.RestDocsSupport;
 import site.dogether.member.entity.Member;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_COMPLETED;
-import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_PENDING;
-import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.*;
 
 @DisplayName("데일리 투두 API 문서화 테스트")
 public class DailyTodoControllerDocsTest extends RestDocsSupport {
@@ -253,12 +258,12 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
         final FindTargetMemberTodayTodoHistoriesDto serviceMockResponse = new FindTargetMemberTodayTodoHistoriesDto(
             3,
             List.of(
-                new TodoHistoryDto(1L, "치킨 먹기", CERTIFY_PENDING.name(), null, null, true),
-                new TodoHistoryDto(2L, "재홍님 갈구기", CERTIFY_PENDING.name(), null, null, true),
-                new TodoHistoryDto(3L, "치킨 먹기", REVIEW_PENDING.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", true),
-                new TodoHistoryDto(4L, "재홍님 갈구기", REVIEW_PENDING.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false),
-                new TodoHistoryDto(5L, "재홍님 갈구기", APPROVE.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false),
-                new TodoHistoryDto(6L, "치킨 먹기", REJECT.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", false)
+                new TodoHistoryDto(1L, "치킨 먹기", CERTIFY_PENDING.name(), null, null, true, null),
+                new TodoHistoryDto(2L, "재홍님 갈구기", CERTIFY_PENDING.name(), null, null, true, null),
+                new TodoHistoryDto(3L, "치킨 먹기", REVIEW_PENDING.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", true, "치킨 부럽다ㅠㅠ"),
+                new TodoHistoryDto(4L, "재홍님 갈구기", REVIEW_PENDING.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요"),
+                new TodoHistoryDto(5L, "재홍님 갈구기", APPROVE.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요"),
+                new TodoHistoryDto(6L, "치킨 먹기", REJECT.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ")
             )
         );
         given(dailyTodoHistoryService.findAllTodayTodoHistories(any(), any(), any()))
@@ -309,7 +314,11 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
                         .type(JsonFieldType.STRING),
                     fieldWithPath("data.todos[].isRead")
                         .description("투두 읽음 여부")
-                        .type(JsonFieldType.BOOLEAN))));
+                        .type(JsonFieldType.BOOLEAN),
+                    fieldWithPath("data.todos[].reviewFeedback")
+                        .description("데일리 투두 인증 검사 피드백")
+                        .optional()
+                        .type(JsonFieldType.STRING))));
     }
 
     @DisplayName("특정 투두 히스토리 읽음 처리 API")


### PR DESCRIPTION
### 😉 연관 이슈
#142 

### 🧑‍💻 수행 작업
- 다른 그룹원의 히스토리에서 피드백을 조회할 수 있는 기능을 추가합니다.

### 📢 참고 사항
X
