### PR TITLE
[BE] 다른 그룹원의 히스토리에서 피드백을 조회할 수 있음에 따라 REST Docs 문서 수정

### DIFF
--- a/src/test/java/site/dogether/dailyTodoHistory/service/DailyTodoHistoryServiceTest.java
+++ b/src/test/java/site/dogether/dailyTodoHistory/service/DailyTodoHistoryServiceTest.java
@@ -133,6 +133,7 @@ public class DailyTodoHistoryServiceTest {
         assertSoftly(softly -> {
             softly.assertThat(targetMemberTodayTodoHistories.currentTodoHistoryToReadIndex()).isEqualTo(0);
             assertThat(targetMemberTodayTodoHistories.todoHistories().get(0).content()).isEqualTo("치킨 먹기");
+            assertThat(targetMemberTodayTodoHistories.todoHistories().get(0).status()).isEqualTo(DailyTodoCertificationReviewStatus.APPROVE.name());
             assertThat(targetMemberTodayTodoHistories.todoHistories().get(0).certificationContent()).isEqualTo("치킨 먹었습니다! 맛있어요!");
             assertThat(targetMemberTodayTodoHistories.todoHistories().get(0).certificationMediaUrl()).isEqualTo("chicken.url");
             assertThat(targetMemberTodayTodoHistories.todoHistories().get(0).isRead()).isFalse();

--- a/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/DailyTodoControllerDocsTest.java
@@ -260,10 +260,10 @@ public class DailyTodoControllerDocsTest extends RestDocsSupport {
             List.of(
                 new TodoHistoryDto(1L, "치킨 먹기", CERTIFY_PENDING.name(), null, null, true, null),
                 new TodoHistoryDto(2L, "재홍님 갈구기", CERTIFY_PENDING.name(), null, null, true, null),
-                new TodoHistoryDto(3L, "치킨 먹기", REVIEW_PENDING.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", true, "치킨 부럽다ㅠㅠ"),
-                new TodoHistoryDto(4L, "재홍님 갈구기", REVIEW_PENDING.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요"),
+                new TodoHistoryDto(3L, "치킨 먹기", REVIEW_PENDING.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", true, null),
+                new TodoHistoryDto(4L, "재홍님 갈구기", REVIEW_PENDING.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, null),
                 new TodoHistoryDto(5L, "재홍님 갈구기", APPROVE.name(), "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요"),
-                new TodoHistoryDto(6L, "치킨 먹기", REJECT.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ")
+                new TodoHistoryDto(6L, "치킨 먹기", REJECT.name(), "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ 심술나서 노인정!")
             )
         );
         given(dailyTodoHistoryService.findAllTodayTodoHistories(any(), any(), any()))


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #142 

### 🧑‍💻 수행 작업
- 다른 그룹원의 히스토리에서 피드백을 조회할 수 있음에 따라 REST Docs 문서를 수정합니다.
  -  status가 REVIEW_PENDING일 경우 reviewFeedback을 null로 응답합니다.

### 📢 참고 사항
X
