### PR TITLE
투두 내용에 특수문자가 들어갈 경우 인증이 안되는 문제 해결

### DIFF
--- a/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
+++ b/src/main/java/site/dogether/dailytodocertification/service/DailyTodoCertificationService.java
@@ -134,7 +134,7 @@ public class DailyTodoCertificationService {
         notificationService.sendNotification(
             reviewer.getId(),
             String.format("%s님의 투두 인증 검사자로 선정되었습니다.", writer.getName()),
-            String.format("투두 내용 : " + dailyTodo.getContent()),
+            String.format("투두 내용 : %s",dailyTodo.getContent()),
             "CERTIFICATION"
         );
     }


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #155

### 🧑‍💻 수행 작업
- 특수 문자가 들어가더라도 문제가 발생하지 않도록 수정

### 📢 참고 사항
X
