### PR TITLE
github actions 배포 시 slack으로 알림 가도록 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -377,6 +377,7 @@ jobs:
         with:
           payload: |
             {
+              "text": "🎉 BE 배포 성공 알림! (${{ needs.setup-deploy.outputs.environment }})",
               "attachments": [
                 {
                   "color": "#36a64f",
@@ -413,6 +414,7 @@ jobs:
         with:
           payload: |
             {
+              "text": "❌ BE 배포 실패 알림ㅜ (${{ needs.setup-deploy.outputs.environment }})",
               "attachments": [
                 {
                   "color": "#ff0000",


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #171

### 🧑‍💻 수행 작업
- github actions 배포 시 slack으로 알림 가도록 설정

### 📢 참고 사항
X
