### PR TITLE
github actions 배포 시 slack으로 알림 가도록 설정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -123,6 +123,7 @@ jobs:
         with:
           payload: |
             {
+              "text": "🙏 BE 배포 시작 알림 (${{ steps.set-environment.outputs.environment }})",
               "blocks": [
                 {
                   "type": "header",


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #171

### 🧑‍💻 수행 작업
- github actions 배포 시 slack으로 알림 가도록 설정

### 📢 참고 사항
X
