### PR TITLE
투두 중간 추가시 나중에 추가된 투두가 위로 배치되도록 정렬 기능 변경

### DIFF
--- a/src/main/java/site/dogether/dailytodo/repository/DailyTodoRepository.java
+++ b/src/main/java/site/dogether/dailytodo/repository/DailyTodoRepository.java
@@ -1,7 +1,5 @@
 package site.dogether.dailytodo.repository;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,6 +8,9 @@ import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodo.entity.DailyTodoStatus;
 import site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus;
 import site.dogether.member.entity.Member;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
 
@@ -32,7 +33,7 @@ public interface DailyTodoRepository extends JpaRepository<DailyTodo, Long> {
         LocalDateTime endDateTime
     );
 
-    List<DailyTodo> findAllByChallengeGroupAndMemberAndStatusAndWrittenAtBetween(
+    List<DailyTodo> findAllByChallengeGroupAndMemberAndStatusAndWrittenAtBetweenOrderByWrittenAtDesc(
         ChallengeGroup challengeGroup,
         Member member,
         DailyTodoStatus status,

--- a/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
+++ b/src/main/java/site/dogether/dailytodo/service/DailyTodoService.java
@@ -1,11 +1,5 @@
 package site.dogether.dailytodo.service;
 
-import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_PENDING;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +22,13 @@ import site.dogether.dailytodohistory.service.DailyTodoHistoryService;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_PENDING;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -160,7 +161,7 @@ public class DailyTodoService {
         final LocalDateTime startDate,
         final LocalDateTime endDate
     ) {
-        final List<DailyTodoDto> certifyPendingTodos = new java.util.ArrayList<>(dailyTodoRepository.findAllByChallengeGroupAndMemberAndStatusAndWrittenAtBetween(
+        final List<DailyTodoDto> certifyPendingTodos = new java.util.ArrayList<>(dailyTodoRepository.findAllByChallengeGroupAndMemberAndStatusAndWrittenAtBetweenOrderByWrittenAtDesc(
                 challengeGroup,
                 member,
                 CERTIFY_PENDING,


### PR DESCRIPTION
### 😉 연관 이슈
#180

### 🧑‍💻 수행 작업
- 미인증 투두 조회시 투두 작성일 기준 내린차순 정렬로 반환되도록 로직 수정

### 📢 참고 사항
기능이 UI적으로 잘 작동하는지 개발 서버에 배포 테스트 후 잘 작동하면 그대로 이슈 종료합니다.
