### PR TITLE
[BE] refactor: ChallengeGroup 생성 인터페이스를 하나로 통일

### DIFF
--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -8,7 +8,6 @@ import lombok.ToString;
 import site.dogether.challengegroup.exception.InvalidChallengeGroupException;
 import site.dogether.common.audit.entity.BaseEntity;
 
-import java.security.SecureRandom;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -26,7 +25,6 @@ public class ChallengeGroup extends BaseEntity {
     private static final int MAXIMUM_GROUP_NAME_LENGTH = 200;
     private static final int MIN_MAXIMUM_MEMBER_COUNT = 2;
     private static final int MAX_MAXIMUM_MEMBER_COUNT = 20;
-    private static final int JOIN_CODE_LENGTH = 8;
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -44,8 +42,8 @@ public class ChallengeGroup extends BaseEntity {
     @Column(name = "end_at", nullable = false)
     private LocalDate endAt;
 
-    @Column(name = "join_code", length = 20, nullable = false, unique = true)
-    private String joinCode;
+    @Embedded
+    private JoinCode joinCode;
 
     @Column(name = "status", length = 10, nullable = false)
     @Enumerated(EnumType.STRING)
@@ -59,6 +57,7 @@ public class ChallengeGroup extends BaseEntity {
         final int maximumMemberCount,
         final LocalDate startAt,
         final LocalDate endAt,
+        final JoinCode joinCode,
         final LocalDateTime createdAt
     ) {
         validateEndAtIsAfterStartAt(startAt, endAt);
@@ -68,7 +67,7 @@ public class ChallengeGroup extends BaseEntity {
             maximumMemberCount,
             startAt,
             endAt,
-            generateJoinCode(),
+            joinCode,
             initStatus(startAt),
             createdAt
         );
@@ -104,18 +103,6 @@ public class ChallengeGroup extends BaseEntity {
         }
     }
 
-    private static String generateJoinCode() {
-        String charSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-        SecureRandom random = new SecureRandom();
-        StringBuilder codeBuilder = new StringBuilder(JOIN_CODE_LENGTH);
-
-        for (int i = 0; i < JOIN_CODE_LENGTH; i++) {
-            int index = random.nextInt(charSet.length());
-            codeBuilder.append(charSet.charAt(index));
-        }
-        return codeBuilder.toString();
-    }
-
     private static ChallengeGroupStatus initStatus(final LocalDate startAt) {
         if (startAt.equals(LocalDate.now())) {
             return RUNNING;
@@ -129,7 +116,7 @@ public class ChallengeGroup extends BaseEntity {
         final int maximumMemberCount,
         final LocalDate startAt,
         final LocalDate endAt,
-        final String joinCode,
+        final JoinCode joinCode,
         final ChallengeGroupStatus status,
         final LocalDateTime createdAt
     ) {

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroup.java
@@ -1,13 +1,6 @@
 package site.dogether.challengegroup.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -65,18 +58,19 @@ public class ChallengeGroup extends BaseEntity {
         final String name,
         final int maximumMemberCount,
         final LocalDate startAt,
-        final LocalDate endAt
+        final LocalDate endAt,
+        final LocalDateTime createdAt
     ) {
         validateEndAtIsAfterStartAt(startAt, endAt);
         return new ChallengeGroup(
             null,
-            validateGroupName(name),
-            validateMaximumMemberCount(maximumMemberCount),
+            name,
+            maximumMemberCount,
             startAt,
             endAt,
             generateJoinCode(),
             initStatus(startAt),
-            LocalDateTime.now()
+            createdAt
         );
     }
 
@@ -140,7 +134,7 @@ public class ChallengeGroup extends BaseEntity {
         final LocalDateTime createdAt
     ) {
         this.id = id;
-        this.name = name;
+        this.name = validateGroupName(name);
         this.maximumMemberCount = validateMaximumMemberCount(maximumMemberCount);
         this.startAt = startAt;
         this.endAt = endAt;

--- a/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupDurationOption.java
+++ b/src/main/java/site/dogether/challengegroup/entity/ChallengeGroupDurationOption.java
@@ -1,11 +1,12 @@
 package site.dogether.challengegroup.entity;
 
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.function.Function;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import site.dogether.challengegroup.exception.InvalidChallengeGroupDurationException;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.function.Function;
 
 @Getter
 @RequiredArgsConstructor

--- a/src/main/java/site/dogether/challengegroup/entity/JoinCode.java
+++ b/src/main/java/site/dogether/challengegroup/entity/JoinCode.java
@@ -1,0 +1,79 @@
+package site.dogether.challengegroup.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.security.SecureRandom;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class JoinCode {
+
+    private static final int JOIN_CODE_LENGTH = 8;
+    private static final String ALL_CHARS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final String EXCLUDED_AMBIGUOUS_CHARS = "0Oo1Iil";
+    private static final String AVAILABLE_CHARS = buildAvailableChars();
+
+    @Column(name = "join_code", length = 20, nullable = false, unique = true)
+    private String value;
+
+    private static String buildAvailableChars() {
+        final StringBuilder builder = new StringBuilder();
+        for (char c : ALL_CHARS.toCharArray()) {
+            if (EXCLUDED_AMBIGUOUS_CHARS.indexOf(c) == -1) {
+                builder.append(c);
+            }
+        }
+        return builder.toString();
+    }
+
+    public static JoinCode generate() {
+        final SecureRandom random = new SecureRandom();
+        final StringBuilder codeBuilder = new StringBuilder(JOIN_CODE_LENGTH);
+
+        for (int i = 0; i < JOIN_CODE_LENGTH; i++) {
+            final int index = random.nextInt(AVAILABLE_CHARS.length());
+            codeBuilder.append(AVAILABLE_CHARS.charAt(index));
+        }
+
+        return new JoinCode(codeBuilder.toString());
+    }
+
+    private JoinCode(final String value) {
+        validateJoinCode(value);
+        this.value = value;
+    }
+
+    private void validateJoinCode(final String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("참가 코드는 null 또는 공백일 수 없습니다.");
+        }
+        if (value.length() != JOIN_CODE_LENGTH) {
+            throw new IllegalArgumentException(
+                String.format("참가 코드는 %d자여야 합니다. (입력된 길이: %d)", JOIN_CODE_LENGTH, value.length())
+            );
+        }
+    }
+
+    @Override
+    public boolean equals(final Object object) {
+        if (object == null || getClass() != object.getClass()) return false;
+        final JoinCode joinCode = (JoinCode) object;
+        return Objects.equals(value, joinCode.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(value);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/src/main/java/site/dogether/challengegroup/repository/ChallengeGroupRepository.java
+++ b/src/main/java/site/dogether/challengegroup/repository/ChallengeGroupRepository.java
@@ -1,15 +1,16 @@
 package site.dogether.challengegroup.repository;
 
-import java.time.LocalDate;
-import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
 
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
 public interface ChallengeGroupRepository extends JpaRepository<ChallengeGroup, Long> {
 
-    Optional<ChallengeGroup> findByJoinCode(String joinCode);
+    Optional<ChallengeGroup> findByJoinCode_Value(String joinCodeValue);
 
     LocalDate findEndAtById(Long id);
 

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -7,27 +7,12 @@ import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.controller.v0.dto.response.IsParticipatingChallengeGroupApiResponseV0;
 import site.dogether.challengegroup.controller.v1.dto.request.CreateChallengeGroupApiRequestV1;
 import site.dogether.challengegroup.controller.v1.dto.response.IsChallengeGroupParticipationRequiredApiResponseV1;
-import site.dogether.challengegroup.entity.AchievementRateCalculator;
-import site.dogether.challengegroup.entity.ChallengeGroup;
-import site.dogether.challengegroup.entity.ChallengeGroupMember;
-import site.dogether.challengegroup.entity.ChallengeGroupStatus;
-import site.dogether.challengegroup.entity.LastSelectedChallengeGroupRecord;
-import site.dogether.challengegroup.exception.AlreadyJoinChallengeGroupException;
-import site.dogether.challengegroup.exception.ChallengeGroupNotFoundException;
-import site.dogether.challengegroup.exception.FinishedChallengeGroupException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupAlreadyFinishedException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupAlreadyFullMemberException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupMaxCountException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupNotFoundException;
-import site.dogether.challengegroup.exception.MemberNotInChallengeGroupException;
+import site.dogether.challengegroup.entity.*;
+import site.dogether.challengegroup.exception.*;
 import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.challengegroup.repository.LastSelectedChallengeGroupRecordRepository;
-import site.dogether.challengegroup.service.dto.ChallengeGroupMemberOverviewDto;
-import site.dogether.challengegroup.service.dto.ChallengeGroupMemberWithAchievementRateDto;
-import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
-import site.dogether.challengegroup.service.dto.JoiningChallengeGroupDto;
-import site.dogether.challengegroup.service.dto.JoiningChallengeGroupsWithLastSelectedGroupIndexDto;
+import site.dogether.challengegroup.service.dto.*;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodo.service.DailyTodoService;
 import site.dogether.dailytodocertification.repository.DailyTodoCertificationCount;
@@ -39,6 +24,7 @@ import site.dogether.member.repository.MemberRepository;
 import site.dogether.notification.service.NotificationService;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.IntStream;
@@ -65,11 +51,13 @@ public class ChallengeGroupService {
 
         final LocalDate startAt = request.challengeGroupStartAtOption().calculateStartAt();
         final LocalDate endAt = request.challengeGroupDurationOption().calculateEndAt(startAt);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = ChallengeGroup.create(
             request.groupName(),
             request.maximumMemberCount(),
             startAt,
-            endAt
+            endAt,
+            createdAt
         );
 
         final ChallengeGroup savedChallengeGroup = challengeGroupRepository.save(challengeGroup);

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -7,10 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.controller.v0.dto.response.IsParticipatingChallengeGroupApiResponseV0;
 import site.dogether.challengegroup.controller.v1.dto.request.CreateChallengeGroupApiRequestV1;
 import site.dogether.challengegroup.controller.v1.dto.response.IsChallengeGroupParticipationRequiredApiResponseV1;
-import site.dogether.challengegroup.entity.AchievementRateCalculator;
-import site.dogether.challengegroup.entity.ChallengeGroup;
-import site.dogether.challengegroup.entity.ChallengeGroupMember;
-import site.dogether.challengegroup.entity.LastSelectedChallengeGroupRecord;
+import site.dogether.challengegroup.entity.*;
 import site.dogether.challengegroup.exception.*;
 import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
@@ -60,6 +57,7 @@ public class ChallengeGroupService {
             request.maximumMemberCount(),
             startAt,
             endAt,
+            JoinCode.generate(),
             createdAt
         );
 
@@ -67,7 +65,7 @@ public class ChallengeGroupService {
         challengeGroupMemberRepository.save(new ChallengeGroupMember(savedChallengeGroup, member));
         saveLastSelectedChallengeGroupRecord(member, savedChallengeGroup);
 
-        return challengeGroup.getJoinCode();
+        return challengeGroup.getJoinCode().toString();
     }
 
     private Member getMember(final Long memberId) {
@@ -112,7 +110,7 @@ public class ChallengeGroupService {
     }
 
     private ChallengeGroup getJoiningChallengeGroup(final String joinCode) {
-        return challengeGroupRepository.findByJoinCode(joinCode)
+        return challengeGroupRepository.findByJoinCode_Value(joinCode)
             .orElseThrow(() -> new JoiningChallengeGroupNotFoundException(String.format("참여 하려는 챌린지 그룹이 존재하지 않습니다. (%s)", joinCode)));
     }
 

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -7,7 +7,10 @@ import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.controller.v0.dto.response.IsParticipatingChallengeGroupApiResponseV0;
 import site.dogether.challengegroup.controller.v1.dto.request.CreateChallengeGroupApiRequestV1;
 import site.dogether.challengegroup.controller.v1.dto.response.IsChallengeGroupParticipationRequiredApiResponseV1;
-import site.dogether.challengegroup.entity.*;
+import site.dogether.challengegroup.entity.AchievementRateCalculator;
+import site.dogether.challengegroup.entity.ChallengeGroup;
+import site.dogether.challengegroup.entity.ChallengeGroupMember;
+import site.dogether.challengegroup.entity.LastSelectedChallengeGroupRecord;
 import site.dogether.challengegroup.exception.*;
 import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
@@ -338,17 +341,5 @@ public class ChallengeGroupService {
             .orElseThrow(() -> new MemberNotInChallengeGroupException(String.format("ChallengeGroup에서 해당하는 멤버를 찾을 수 없습니다. member={}, challengeGroup={}", target, groupMembers.get(0).getChallengeGroup())));
 
         return challengeGroupMemberWithAchievementRate.indexOf(myAchievementRate) + 1;
-    }
-
-    @Transactional
-    public void updateChallengeGroupStatus() {
-        List<ChallengeGroup> notFinishedGroups = challengeGroupRepository.findByStatusNot(ChallengeGroupStatus.FINISHED);
-
-        for (ChallengeGroup notFinishedGroup : notFinishedGroups) {
-            notFinishedGroup.updateStatus();
-            log.info("챌린지 그룹 상태 업데이트: groupId={}, status={}", notFinishedGroup.getId(), notFinishedGroup.getStatus());
-        }
-
-        challengeGroupRepository.saveAll(notFinishedGroups);
     }
 }

--- a/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
+++ b/src/main/java/site/dogether/challengegroup/service/ChallengeGroupService.java
@@ -52,7 +52,7 @@ public class ChallengeGroupService {
         final LocalDate startAt = request.challengeGroupStartAtOption().calculateStartAt();
         final LocalDate endAt = request.challengeGroupDurationOption().calculateEndAt(startAt);
         final LocalDateTime createdAt = LocalDateTime.now();
-        final ChallengeGroup challengeGroup = ChallengeGroup.create(
+        final ChallengeGroup challengeGroup = new ChallengeGroup(
             request.groupName(),
             request.maximumMemberCount(),
             startAt,

--- a/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
+++ b/src/main/java/site/dogether/challengegroup/service/dto/JoiningChallengeGroupDto.java
@@ -1,7 +1,8 @@
 package site.dogether.challengegroup.service.dto;
 
-import java.time.format.DateTimeFormatter;
 import site.dogether.challengegroup.entity.ChallengeGroup;
+
+import java.time.format.DateTimeFormatter;
 
 public record JoiningChallengeGroupDto(
     Long groupId,
@@ -26,7 +27,7 @@ public record JoiningChallengeGroupDto(
             joiningGroup.getName(),
             currentMemberCount,
             joiningGroup.getMaximumMemberCount(),
-            joiningGroup.getJoinCode(),
+            joiningGroup.getJoinCode().getValue(),
             joiningGroup.getStatus().name(),
             joiningGroup.getStartAt().format(formatter),
             joiningGroup.getEndAt().format(formatter),

--- a/src/main/java/site/dogether/challengegroup/service/scheduler/ChallengeGroupStatusScheduler.java
+++ b/src/main/java/site/dogether/challengegroup/service/scheduler/ChallengeGroupStatusScheduler.java
@@ -3,16 +3,15 @@ package site.dogether.challengegroup.service.scheduler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import site.dogether.challengegroup.service.ChallengeGroupService;
 
 @RequiredArgsConstructor
 @Component
 public class ChallengeGroupStatusScheduler {
 
-    private final ChallengeGroupService challengeGroupService;
+    private final ChallengeGroupStatusUpdateService challengeGroupStatusUpdateService;
 
     @Scheduled(cron = "0 0 0 * * *")
     public void runStatusUpdate() {
-        challengeGroupService.updateChallengeGroupStatus();
+        challengeGroupStatusUpdateService.updateChallengeGroupStatus();
     }
 }

--- a/src/main/java/site/dogether/challengegroup/service/scheduler/ChallengeGroupStatusUpdateService.java
+++ b/src/main/java/site/dogether/challengegroup/service/scheduler/ChallengeGroupStatusUpdateService.java
@@ -21,9 +21,9 @@ public class ChallengeGroupStatusUpdateService {
     @Transactional
     @Scheduled(cron = "0 0 * * * *")
     public void updateChallengeGroupStatus() {
-        List<ChallengeGroup> notFinishedGroups = challengeGroupRepository.findByStatusNot(ChallengeGroupStatus.FINISHED);
+        final List<ChallengeGroup> notFinishedGroups = challengeGroupRepository.findByStatusNot(ChallengeGroupStatus.FINISHED);
 
-        for (ChallengeGroup notFinishedGroup : notFinishedGroups) {
+        for (final ChallengeGroup notFinishedGroup : notFinishedGroups) {
             notFinishedGroup.updateStatus();
             log.info("챌린지 그룹 상태 업데이트: groupId={}, status={}", notFinishedGroup.getId(), notFinishedGroup.getStatus());
         }

--- a/src/main/java/site/dogether/challengegroup/service/scheduler/ChallengeGroupStatusUpdateService.java
+++ b/src/main/java/site/dogether/challengegroup/service/scheduler/ChallengeGroupStatusUpdateService.java
@@ -1,0 +1,33 @@
+package site.dogether.challengegroup.service.scheduler;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import site.dogether.challengegroup.entity.ChallengeGroup;
+import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.repository.ChallengeGroupRepository;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ChallengeGroupStatusUpdateService {
+
+    private final ChallengeGroupRepository challengeGroupRepository;
+
+    @Transactional
+    @Scheduled(cron = "0 0 * * * *")
+    public void updateChallengeGroupStatus() {
+        List<ChallengeGroup> notFinishedGroups = challengeGroupRepository.findByStatusNot(ChallengeGroupStatus.FINISHED);
+
+        for (ChallengeGroup notFinishedGroup : notFinishedGroups) {
+            notFinishedGroup.updateStatus();
+            log.info("챌린지 그룹 상태 업데이트: groupId={}, status={}", notFinishedGroup.getId(), notFinishedGroup.getStatus());
+        }
+
+        challengeGroupRepository.saveAll(notFinishedGroups);
+    }
+}

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -20,8 +20,8 @@ import site.dogether.dailytodocertification.repository.DailyTodoCertificationRep
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
-import site.dogether.memberactivity.controller.v1.dto.response.GetGroupActivityStatApiResponseV1;
 import site.dogether.memberactivity.controller.v0.dto.response.GetMemberAllStatsApiResponseV0;
+import site.dogether.memberactivity.controller.v1.dto.response.GetGroupActivityStatApiResponseV1;
 import site.dogether.memberactivity.entity.DailyTodoStats;
 import site.dogether.memberactivity.exception.InvalidParameterException;
 import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
@@ -96,7 +96,7 @@ public class MemberActivityService {
                 challengeGroup.getName(),
                 challengeGroup.getMaximumMemberCount(),
                 currentMemberCount,
-                challengeGroup.getJoinCode(),
+                challengeGroup.getJoinCode().getValue(),
                 endAt
         );
     }

--- a/src/test/java/site/dogether/challengegroup/entity/AchievementRateCalculatorTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/AchievementRateCalculatorTest.java
@@ -28,13 +28,11 @@ class AchievementRateCalculatorTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-            1L,
             "그로밋의 일상생활",
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
             JoinCode.generate(),
-            ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
     }

--- a/src/test/java/site/dogether/challengegroup/entity/AchievementRateCalculatorTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/AchievementRateCalculatorTest.java
@@ -33,7 +33,7 @@ class AchievementRateCalculatorTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupDurationOptionTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupDurationOptionTest.java
@@ -1,12 +1,13 @@
 package site.dogether.challengegroup.entity;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-
-import java.time.LocalDate;
-import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.LocalDate;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
 class ChallengeGroupDurationOptionTest {
 

--- a/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
@@ -21,9 +21,10 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final JoinCode joinCode = JoinCode.generate();
         final LocalDateTime createdAt = LocalDateTime.now();
 
-        final ChallengeGroup created = ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt);
+        final ChallengeGroup created = ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, joinCode, createdAt);
 
         assertSoftly(softly -> {
             assertThat(created.getId()).isNull();
@@ -44,7 +45,7 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
-        final String joinCode = "join_code";
+        final JoinCode joinCode = JoinCode.generate();
         final ChallengeGroupStatus status = ChallengeGroupStatus.RUNNING;
         final LocalDateTime createdAt = LocalDateTime.now();
 
@@ -66,9 +67,10 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final JoinCode joinCode = JoinCode.generate();
         final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, joinCode, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(String.format("챌린지 그룹 이름으로 null 혹은 공백을 입력할 수 없습니다. (name : %s)", name));
     }
@@ -79,9 +81,10 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final JoinCode joinCode = JoinCode.generate();
         final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, joinCode, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(String.format("챌린지 그룹 이름은 1자 이상, 200자 이하만 가능합니다. (name : %s)", name));
     }
@@ -92,9 +95,10 @@ class ChallengeGroupTest {
         final String name = "매일 러닝 모임";
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final JoinCode joinCode = JoinCode.generate();
         final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, joinCode, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(String.format(
                         "챌린지 그룹 최대 인원은 2명 이상, 20명 이하만 가능합니다. (input : %d)", maximumMemberCount)
@@ -107,9 +111,10 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.minusDays(1);
+        final JoinCode joinCode = JoinCode.generate();
         final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, joinCode, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(
                         String.format("시작일은 종료일보다 늦을 수 없습니다. (startAt : %s, endAt : %s)", startAt, endAt)
@@ -126,7 +131,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.READY,
                 createdAt
         );
@@ -147,7 +152,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.RUNNING,
                 createdAt
         );
@@ -169,7 +174,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(duration),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.FINISHED,
                 createdAt
         );
@@ -189,7 +194,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.READY,
                 createdAt
         );
@@ -219,7 +224,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.RUNNING,
                 createdAt
         );
@@ -240,7 +245,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.FINISHED,
                 createdAt
         );
@@ -260,7 +265,7 @@ class ChallengeGroupTest {
                 10,
                 startAt,
                 startAt.plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.READY,
                 createdAt
         );
@@ -280,7 +285,7 @@ class ChallengeGroupTest {
                 10,
                 endAt.minusDays(7),
                 endAt,
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.RUNNING,
                 createdAt
         );
@@ -300,7 +305,7 @@ class ChallengeGroupTest {
                 10,
                 endAt.minusDays(7),
                 endAt,
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.D_DAY,
                 createdAt
         );

--- a/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
@@ -69,6 +69,18 @@ class ChallengeGroupTest {
                 .hasMessage(String.format("챌린지 그룹 이름으로 null 혹은 공백을 입력할 수 없습니다. (name : %s)", name));
     }
 
+    @Test
+    void 챌린지_그룹_이름이_200자를_초과하면_예외가_발생한다() {
+        final String name = "a".repeat(201);
+        final int maximumMemberCount = 10;
+        final LocalDate startAt = LocalDate.now();
+        final LocalDate endAt = startAt.plusDays(7);
+
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt))
+                .isInstanceOf(InvalidChallengeGroupException.class)
+                .hasMessage(String.format("챌린지 그룹 이름은 1자 이상, 200자 이하만 가능합니다. (name : %s)", name));
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {1, 21})
     void 유효하지_않은_챌린지_그룹_최대_참여_인원을_입력하면_예외가_발생한다(final int maximumMemberCount) {

--- a/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/ChallengeGroupTest.java
@@ -21,8 +21,9 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final LocalDateTime createdAt = LocalDateTime.now();
 
-        final ChallengeGroup created = ChallengeGroup.create(name, maximumMemberCount, startAt, endAt);
+        final ChallengeGroup created = ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt);
 
         assertSoftly(softly -> {
             assertThat(created.getId()).isNull();
@@ -32,6 +33,7 @@ class ChallengeGroupTest {
             assertThat(created.getEndAt()).isEqualTo(endAt);
             assertThat(created.getJoinCode()).isNotNull();
             assertThat(created.getStatus()).isEqualTo(ChallengeGroupStatus.RUNNING);
+            assertThat(created.getCreatedAt()).isEqualTo(createdAt);
         });
     }
 
@@ -44,6 +46,7 @@ class ChallengeGroupTest {
         final LocalDate endAt = startAt.plusDays(7);
         final String joinCode = "join_code";
         final ChallengeGroupStatus status = ChallengeGroupStatus.RUNNING;
+        final LocalDateTime createdAt = LocalDateTime.now();
 
         assertThatCode(() -> new ChallengeGroup(
                 id,
@@ -53,7 +56,7 @@ class ChallengeGroupTest {
                 endAt,
                 joinCode,
                 status,
-            LocalDateTime.now()
+                createdAt
         )).doesNotThrowAnyException();
     }
 
@@ -63,8 +66,9 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(String.format("챌린지 그룹 이름으로 null 혹은 공백을 입력할 수 없습니다. (name : %s)", name));
     }
@@ -75,8 +79,9 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(String.format("챌린지 그룹 이름은 1자 이상, 200자 이하만 가능합니다. (name : %s)", name));
     }
@@ -87,8 +92,9 @@ class ChallengeGroupTest {
         final String name = "매일 러닝 모임";
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.plusDays(7);
+        final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(String.format(
                         "챌린지 그룹 최대 인원은 2명 이상, 20명 이하만 가능합니다. (input : %d)", maximumMemberCount)
@@ -101,8 +107,9 @@ class ChallengeGroupTest {
         final int maximumMemberCount = 10;
         final LocalDate startAt = LocalDate.now();
         final LocalDate endAt = startAt.minusDays(1);
+        final LocalDateTime createdAt = LocalDateTime.now();
 
-        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt))
+        assertThatThrownBy(() -> ChallengeGroup.create(name, maximumMemberCount, startAt, endAt, createdAt))
                 .isInstanceOf(InvalidChallengeGroupException.class)
                 .hasMessage(
                         String.format("시작일은 종료일보다 늦을 수 없습니다. (startAt : %s, endAt : %s)", startAt, endAt)
@@ -112,6 +119,7 @@ class ChallengeGroupTest {
     @Test
     void 챌린지_그룹의_진행일을_계산한다__READY이면_진행일은_0이다() {
         final LocalDate startAt = LocalDate.now().plusDays(1);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -120,7 +128,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(7),
                 "join_code",
                 ChallengeGroupStatus.READY,
-            LocalDateTime.now()
+                createdAt
         );
 
         final int progressDay = challengeGroup.getProgressDay();
@@ -132,6 +140,7 @@ class ChallengeGroupTest {
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7})
     void 챌린지_그룹의_진행일을_계산한다__RUNNING이면_하루씩_증가한다(final int daysSinceStart) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -140,7 +149,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(7),
                 "join_code",
                 ChallengeGroupStatus.RUNNING,
-            LocalDateTime.now()
+                createdAt
         );
 
         final int progressDay = challengeGroup.getProgressDay();
@@ -153,6 +162,7 @@ class ChallengeGroupTest {
     void 챌린지_그룹의_진행일을_계산한다__FINISHED(final int daysSinceStart) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
         int duration = 7;
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -161,7 +171,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(duration),
                 "join_code",
                 ChallengeGroupStatus.FINISHED,
-            LocalDateTime.now()
+                createdAt
         );
 
         final int progressDay = challengeGroup.getProgressDay();
@@ -172,6 +182,7 @@ class ChallengeGroupTest {
     @Test
     void 챌린지_그룹의_진행률을_계산한다__READY이면_진행률은_0이다() {
         final LocalDate startAt = LocalDate.now().plusDays(1);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -180,7 +191,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(7),
                 "join_code",
                 ChallengeGroupStatus.READY,
-            LocalDateTime.now()
+                createdAt
         );
 
         final double progressRate = challengeGroup.getProgressRate();
@@ -201,6 +212,7 @@ class ChallengeGroupTest {
     })
     void 챌린지_그룹의_진행률을_계산한다__RUNNING이면_진행일_나누기_종료일_포함한_기간(final int daysSinceStart, final double expected) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -209,7 +221,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(7),
                 "join_code",
                 ChallengeGroupStatus.RUNNING,
-            LocalDateTime.now()
+                createdAt
         );
 
         final double progressRate = challengeGroup.getProgressRate();
@@ -221,6 +233,7 @@ class ChallengeGroupTest {
     @ValueSource(ints = {8, 9})
     void 챌린지_그룹의_진행률을_계산한다__FINISHED이면_1이다(final int daysSinceStart) {
         final LocalDate startAt = LocalDate.now().minusDays(daysSinceStart);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -229,7 +242,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(7),
                 "join_code",
                 ChallengeGroupStatus.FINISHED,
-            LocalDateTime.now()
+                createdAt
         );
 
         final double progressRate = challengeGroup.getProgressRate();
@@ -240,6 +253,7 @@ class ChallengeGroupTest {
     @Test
     void 챌린지_그룹의_상태를_갱신한다__READY에서_RUNNING으로() {
         final LocalDate startAt = LocalDate.now();
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -248,7 +262,7 @@ class ChallengeGroupTest {
                 startAt.plusDays(7),
                 "join_code",
                 ChallengeGroupStatus.READY,
-            LocalDateTime.now()
+                createdAt
         );
 
         challengeGroup.updateStatus();
@@ -259,6 +273,7 @@ class ChallengeGroupTest {
     @Test
     void 챌린지_그룹의_상태를_갱신한다__RUNNING에서_D_DAY로() {
         final LocalDate endAt = LocalDate.now();
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -267,7 +282,7 @@ class ChallengeGroupTest {
                 endAt,
                 "join_code",
                 ChallengeGroupStatus.RUNNING,
-            LocalDateTime.now()
+                createdAt
         );
 
         challengeGroup.updateStatus();
@@ -278,6 +293,7 @@ class ChallengeGroupTest {
     @Test
     void 챌린지_그룹의_상태를_갱신한다__D_DAY에서_FINISHED으로() {
         final LocalDate endAt = LocalDate.now().minusDays(1);
+        final LocalDateTime createdAt = LocalDateTime.now();
         final ChallengeGroup challengeGroup = new ChallengeGroup(
                 1L,
                 "매일 러닝 모임",
@@ -286,7 +302,7 @@ class ChallengeGroupTest {
                 endAt,
                 "join_code",
                 ChallengeGroupStatus.D_DAY,
-            LocalDateTime.now()
+                createdAt
         );
 
         challengeGroup.updateStatus();

--- a/src/test/java/site/dogether/challengegroup/entity/JoinCodeTest.java
+++ b/src/test/java/site/dogether/challengegroup/entity/JoinCodeTest.java
@@ -1,0 +1,56 @@
+package site.dogether.challengegroup.entity;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Constructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JoinCodeTest {
+
+    @Test
+    void 참가_코드를_생성한다() {
+        final JoinCode joinCode = JoinCode.generate();
+
+        assertThat(joinCode).isNotNull();
+        assertThat(joinCode.getValue()).hasSize(8);
+    }
+
+    @Test
+    void 생성된_참가_코드는_영문자와_숫자로_구성된다() {
+        final JoinCode joinCode = JoinCode.generate();
+
+        assertThat(joinCode.getValue()).matches("^[a-zA-Z0-9]{8}$");
+    }
+
+    @Test
+    void 참가_코드_생성_시_매번_다른_값이_생성된다() {
+        final JoinCode joinCode1 = JoinCode.generate();
+        final JoinCode joinCode2 = JoinCode.generate();
+
+        assertThat(joinCode1.getValue()).isNotEqualTo(joinCode2.getValue());
+    }
+
+    @Test
+    void 같은_값을_가진_참가_코드는_동일하다() throws Exception {
+        final Constructor<JoinCode> constructor = JoinCode.class.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+
+        final JoinCode joinCode1 = constructor.newInstance("abcd1234");
+        final JoinCode joinCode2 = constructor.newInstance("abcd1234");
+
+        assertThat(joinCode1).isEqualTo(joinCode2);
+        assertThat(joinCode1.hashCode()).isEqualTo(joinCode2.hashCode());
+    }
+
+    @Test
+    void 다른_값을_가진_참가_코드는_다르다() throws Exception {
+        final Constructor<JoinCode> constructor = JoinCode.class.getDeclaredConstructor(String.class);
+        constructor.setAccessible(true);
+
+        final JoinCode joinCode1 = constructor.newInstance("abcd1234");
+        final JoinCode joinCode2 = constructor.newInstance("efgh5678");
+
+        assertThat(joinCode1).isNotEqualTo(joinCode2);
+    }
+}

--- a/src/test/java/site/dogether/challengegroup/service/ChallengeGroupServiceTest.java
+++ b/src/test/java/site/dogether/challengegroup/service/ChallengeGroupServiceTest.java
@@ -8,12 +8,8 @@ import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.controller.v1.dto.request.CreateChallengeGroupApiRequestV1;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupMember;
-import site.dogether.challengegroup.exception.AlreadyJoinChallengeGroupException;
-import site.dogether.challengegroup.exception.ChallengeGroupNotFoundException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupAlreadyFullMemberException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupMaxCountException;
-import site.dogether.challengegroup.exception.JoiningChallengeGroupNotFoundException;
-import site.dogether.challengegroup.exception.MemberNotInChallengeGroupException;
+import site.dogether.challengegroup.entity.JoinCode;
+import site.dogether.challengegroup.exception.*;
 import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.challengegroup.service.dto.JoinChallengeGroupDto;
@@ -200,6 +196,7 @@ class ChallengeGroupServiceTest {
                 10,
                 LocalDate.now(),
                 LocalDate.now().plusDays(7),
+                JoinCode.generate(),
                 createdAt
         ));
         ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.save(
@@ -233,6 +230,7 @@ class ChallengeGroupServiceTest {
                 10,
                 LocalDate.now(),
                 LocalDate.now().plusDays(7),
+                JoinCode.generate(),
                 createdAt
         ));
 

--- a/src/test/java/site/dogether/challengegroup/service/ChallengeGroupServiceTest.java
+++ b/src/test/java/site/dogether/challengegroup/service/ChallengeGroupServiceTest.java
@@ -191,7 +191,7 @@ class ChallengeGroupServiceTest {
         //given
         Member member1 = memberRepository.save(Member.create("providerId1", "폰트"));
         LocalDateTime createdAt = LocalDateTime.now();
-        ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
+        ChallengeGroup challengeGroup = challengeGroupRepository.save(new ChallengeGroup(
                 "운동 같이 하자",
                 10,
                 LocalDate.now(),
@@ -225,7 +225,7 @@ class ChallengeGroupServiceTest {
         //given
         Member member1 = memberRepository.save(Member.create("providerId1", "폰트"));
         LocalDateTime createdAt = LocalDateTime.now();
-        ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
+        ChallengeGroup challengeGroup = challengeGroupRepository.save(new ChallengeGroup(
                 "운동 같이 하자",
                 10,
                 LocalDate.now(),

--- a/src/test/java/site/dogether/challengegroup/service/ChallengeGroupServiceTest.java
+++ b/src/test/java/site/dogether/challengegroup/service/ChallengeGroupServiceTest.java
@@ -21,6 +21,7 @@ import site.dogether.member.entity.Member;
 import site.dogether.member.repository.MemberRepository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
@@ -193,11 +194,13 @@ class ChallengeGroupServiceTest {
     void 챌린지_그룹을_탈퇴한다() {
         //given
         Member member1 = memberRepository.save(Member.create("providerId1", "폰트"));
+        LocalDateTime createdAt = LocalDateTime.now();
         ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
                 "운동 같이 하자",
                 10,
                 LocalDate.now(),
-                LocalDate.now().plusDays(7)
+                LocalDate.now().plusDays(7),
+                createdAt
         ));
         ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.save(
                 new ChallengeGroupMember(challengeGroup, member1));
@@ -224,11 +227,13 @@ class ChallengeGroupServiceTest {
     void 속해있지_않은_챌린지_그룹을_탈퇴하면_예외가_발생한다() {
         //given
         Member member1 = memberRepository.save(Member.create("providerId1", "폰트"));
+        LocalDateTime createdAt = LocalDateTime.now();
         ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
                 "운동 같이 하자",
                 10,
                 LocalDate.now(),
-                LocalDate.now().plusDays(7)
+                LocalDate.now().plusDays(7),
+                createdAt
         ));
 
         //when & then

--- a/src/test/java/site/dogether/dailyTodoHistory/service/DailyTodoHistoryServiceTest.java
+++ b/src/test/java/site/dogether/dailyTodoHistory/service/DailyTodoHistoryServiceTest.java
@@ -1,11 +1,5 @@
 package site.dogether.dailyTodoHistory.service;
 
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +7,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodo.entity.DailyTodos;
@@ -28,6 +23,13 @@ import site.dogether.member.entity.Member;
 import site.dogether.member.repository.MemberRepository;
 import site.dogether.memberactivity.entity.DailyTodoStats;
 import site.dogether.memberactivity.repository.DailyTodoStatsRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Transactional
 @SpringBootTest
@@ -48,7 +50,7 @@ public class DailyTodoHistoryServiceTest {
                 8,
                 LocalDate.now(),
                 LocalDate.now().plusDays(7),
-                "join_code",
+                JoinCode.generate(),
                 ChallengeGroupStatus.RUNNING,
                 LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/dailyTodoHistory/service/DailyTodoHistoryServiceTest.java
+++ b/src/test/java/site/dogether/dailyTodoHistory/service/DailyTodoHistoryServiceTest.java
@@ -45,13 +45,11 @@ public class DailyTodoHistoryServiceTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-                null,
                 "성욱이와 친구들",
                 8,
                 LocalDate.now(),
                 LocalDate.now().plusDays(7),
                 JoinCode.generate(),
-                ChallengeGroupStatus.RUNNING,
                 LocalDateTime.now().plusHours(1)
         );
     }

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
@@ -29,13 +29,11 @@ class DailyTodoTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-            1L,
             "성욱이와 친구들",
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
             JoinCode.generate(),
-            ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
     }

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodoTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.dailytodo.exception.InvalidDailyTodoException;
 import site.dogether.dailytodo.exception.NotCertifyPendingDailyTodoException;
 import site.dogether.dailytodo.exception.NotCreatedTodayDailyTodoException;
@@ -33,7 +34,7 @@ class DailyTodoTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodosTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodosTest.java
@@ -25,13 +25,11 @@ class DailyTodosTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-            1L,
             "성욱이와 친구들",
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
             JoinCode.generate(),
-            ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
     }

--- a/src/test/java/site/dogether/dailytodo/entity/DailyTodosTest.java
+++ b/src/test/java/site/dogether/dailytodo/entity/DailyTodosTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.dailytodo.exception.InvalidDailyTodoException;
 import site.dogether.member.entity.Member;
 
@@ -29,7 +30,7 @@ class DailyTodosTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
+++ b/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
@@ -1,12 +1,6 @@
 package site.dogether.dailytodo.service;
 
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import jakarta.transaction.Transactional;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,6 +10,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupMember;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.challengegroup.exception.ChallengeGroupNotFoundException;
 import site.dogether.challengegroup.exception.MemberNotInChallengeGroupException;
 import site.dogether.challengegroup.exception.NotRunningChallengeGroupException;
@@ -24,6 +19,13 @@ import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.member.entity.Member;
 import site.dogether.member.exception.MemberNotFoundException;
 import site.dogether.member.repository.MemberRepository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
 @SpringBootTest
@@ -51,7 +53,7 @@ class DailyTodoServiceTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
@@ -64,7 +66,7 @@ class DailyTodoServiceTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             status,
             LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
+++ b/src/test/java/site/dogether/dailytodo/service/DailyTodoServiceTest.java
@@ -48,28 +48,46 @@ class DailyTodoServiceTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-            null,
             "성욱이와 친구들",
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
             JoinCode.generate(),
-            ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
     }
 
     private static ChallengeGroup createChallengeGroup(final ChallengeGroupStatus status) {
-        return new ChallengeGroup(
-            null,
+        final LocalDate startAt;
+        final LocalDate endAt;
+        switch (status) {
+            case READY -> {
+                startAt = LocalDate.now().plusDays(1);
+                endAt = startAt.plusDays(7);
+            }
+            case D_DAY -> {
+                endAt = LocalDate.now();
+                startAt = endAt.minusDays(7);
+            }
+            case FINISHED -> {
+                endAt = LocalDate.now().minusDays(1);
+                startAt = endAt.minusDays(7);
+            }
+            default -> {
+                startAt = LocalDate.now();
+                endAt = startAt.plusDays(7);
+            }
+        }
+        final ChallengeGroup challengeGroup = new ChallengeGroup(
             "성욱이와 친구들",
             8,
-            LocalDate.now(),
-            LocalDate.now().plusDays(7),
+            startAt,
+            endAt,
             JoinCode.generate(),
-            status,
             LocalDateTime.now().plusHours(1)
         );
+        challengeGroup.updateStatus();
+        return challengeGroup;
     }
 
     private static ChallengeGroupMember createChallengeGroupMember(final ChallengeGroup challengeGroup, final Member member) {

--- a/src/test/java/site/dogether/dailytodocertification/entity/DailyTodoCertificationTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/entity/DailyTodoCertificationTest.java
@@ -23,13 +23,11 @@ class DailyTodoCertificationTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-            1L,
             "성욱이와 친구들",
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
             JoinCode.generate(),
-            ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
     }

--- a/src/test/java/site/dogether/dailytodocertification/entity/DailyTodoCertificationTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/entity/DailyTodoCertificationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodo.entity.DailyTodoStatus;
 import site.dogether.dailytodocertification.exception.InvalidDailyTodoCertificationException;
@@ -14,7 +15,8 @@ import site.dogether.member.entity.Member;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static site.dogether.dailytodocertification.entity.DailyTodoCertification.MAXIMUM_ALLOWED_CONTENT_LENGTH;
 
 class DailyTodoCertificationTest {
@@ -26,7 +28,7 @@ class DailyTodoCertificationTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
@@ -47,13 +47,11 @@ class DailyTodoCertificationServiceTest {
 
     private static ChallengeGroup createChallengeGroup() {
         return new ChallengeGroup(
-            null,
             "성욱이와 친구들",
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
             JoinCode.generate(),
-            ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );
     }

--- a/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
+++ b/src/test/java/site/dogether/dailytodocertification/service/DailyTodoCertificationServiceTest.java
@@ -8,6 +8,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.dailytodo.entity.DailyTodo;
 import site.dogether.dailytodo.entity.DailyTodoStatus;
@@ -29,8 +30,8 @@ import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static site.dogether.dailytodo.entity.DailyTodoStatus.*;
-import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.*;
+import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_COMPLETED;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.REVIEW_PENDING;
 
 @Transactional
 @SpringBootTest
@@ -51,7 +52,7 @@ class DailyTodoCertificationServiceTest {
             8,
             LocalDate.now(),
             LocalDate.now().plusDays(7),
-            "join_code",
+            JoinCode.generate(),
             ChallengeGroupStatus.RUNNING,
             LocalDateTime.now().plusHours(1)
         );

--- a/src/test/java/site/dogether/docs/dailytodo/v1/DailyTodoControllerV1DocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/v1/DailyTodoControllerV1DocsTest.java
@@ -6,6 +6,7 @@ import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import site.dogether.challengegroup.entity.ChallengeGroup;
 import site.dogether.challengegroup.entity.ChallengeGroupStatus;
+import site.dogether.challengegroup.entity.JoinCode;
 import site.dogether.dailytodo.controller.v1.DailyTodoControllerV1;
 import site.dogether.dailytodo.controller.v1.dto.request.CreateDailyTodosApiRequestV1;
 import site.dogether.dailytodo.entity.DailyTodo;
@@ -122,7 +123,7 @@ public class DailyTodoControllerV1DocsTest extends RestDocsSupport {
     @Test
     void getMyDailyTodosWithCertificationInputDateV1() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly", "https://영재님_얼짱_각도.png", LocalDateTime.now());
-        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING, LocalDateTime.now().plusHours(1));
+        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), JoinCode.generate(), ChallengeGroupStatus.RUNNING, LocalDateTime.now().plusHours(1));
         final List<DailyTodo> dailyTodos = List.of(
             new DailyTodo(1L, challengeGroup, doer, "운동 하기", CERTIFY_COMPLETED, LocalDateTime.now()),
             new DailyTodo(2L, challengeGroup, doer, "인강 듣기", CERTIFY_COMPLETED, LocalDateTime.now()),
@@ -195,7 +196,7 @@ public class DailyTodoControllerV1DocsTest extends RestDocsSupport {
     void getMyDailyTodosWithCertificationInputDateAndTodoStatusV1() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly", "https://영재님_얼짱_각도.png", LocalDateTime.now());
         final Member reviewer = new Member(2L, "elmo-id", "elmo", "https://영재님_얼짱_각도.png", LocalDateTime.now());
-        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), "CODE", ChallengeGroupStatus.RUNNING, LocalDateTime.now().plusHours(1));
+        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), JoinCode.generate(), ChallengeGroupStatus.RUNNING, LocalDateTime.now().plusHours(1));
         final DailyTodo dailyTodo = new DailyTodo(2L, challengeGroup, doer,  "운동 하기", CERTIFY_COMPLETED, LocalDateTime.now().plusHours(2));
         final DailyTodoCertification dailyTodoCertification = new DailyTodoCertification(1L, dailyTodo, "운동 개조짐 ㅋㅋㅋㅋ", "https://image.url", REVIEW_PENDING, null, LocalDateTime.now().plusHours(3));
         final List<DailyTodoDto> dailyTodoDtos = List.of(new DailyTodoDto(dailyTodo, dailyTodoCertification));

--- a/src/test/java/site/dogether/docs/dailytodo/v1/DailyTodoControllerV1DocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/v1/DailyTodoControllerV1DocsTest.java
@@ -123,7 +123,7 @@ public class DailyTodoControllerV1DocsTest extends RestDocsSupport {
     @Test
     void getMyDailyTodosWithCertificationInputDateV1() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly", "https://영재님_얼짱_각도.png", LocalDateTime.now());
-        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), JoinCode.generate(), ChallengeGroupStatus.RUNNING, LocalDateTime.now().plusHours(1));
+        final ChallengeGroup challengeGroup = new ChallengeGroup("켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), JoinCode.generate(), LocalDateTime.now().plusHours(1));
         final List<DailyTodo> dailyTodos = List.of(
             new DailyTodo(1L, challengeGroup, doer, "운동 하기", CERTIFY_COMPLETED, LocalDateTime.now()),
             new DailyTodo(2L, challengeGroup, doer, "인강 듣기", CERTIFY_COMPLETED, LocalDateTime.now()),
@@ -196,7 +196,7 @@ public class DailyTodoControllerV1DocsTest extends RestDocsSupport {
     void getMyDailyTodosWithCertificationInputDateAndTodoStatusV1() throws Exception {
         final Member doer = new Member(1L, "kelly-id", "kelly", "https://영재님_얼짱_각도.png", LocalDateTime.now());
         final Member reviewer = new Member(2L, "elmo-id", "elmo", "https://영재님_얼짱_각도.png", LocalDateTime.now());
-        final ChallengeGroup challengeGroup = new ChallengeGroup(1L, "켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), JoinCode.generate(), ChallengeGroupStatus.RUNNING, LocalDateTime.now().plusHours(1));
+        final ChallengeGroup challengeGroup = new ChallengeGroup("켈리와 친구들", 6, LocalDate.now(), LocalDate.now().plusDays(7), JoinCode.generate(), LocalDateTime.now().plusHours(1));
         final DailyTodo dailyTodo = new DailyTodo(2L, challengeGroup, doer,  "운동 하기", CERTIFY_COMPLETED, LocalDateTime.now().plusHours(2));
         final DailyTodoCertification dailyTodoCertification = new DailyTodoCertification(1L, dailyTodo, "운동 개조짐 ㅋㅋㅋㅋ", "https://image.url", REVIEW_PENDING, null, LocalDateTime.now().plusHours(3));
         final List<DailyTodoDto> dailyTodoDtos = List.of(new DailyTodoDto(dailyTodo, dailyTodoCertification));

--- a/src/test/java/site/dogether/member/service/MemberServiceTest.java
+++ b/src/test/java/site/dogether/member/service/MemberServiceTest.java
@@ -4,14 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import site.dogether.challengegroup.entity.ChallengeGroup;
-import site.dogether.challengegroup.entity.ChallengeGroupMember;
-import site.dogether.challengegroup.repository.ChallengeGroupMemberRepository;
-import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.member.entity.Member;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,8 +13,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class MemberServiceTest {
 
     @Autowired private MemberService memberService;
-    @Autowired private ChallengeGroupRepository challengeGroupRepository;
-    @Autowired private ChallengeGroupMemberRepository challengeGroupMemberRepository;
 
     @Test
     void 신규_회원을_저장한다() {
@@ -48,30 +39,5 @@ class MemberServiceTest {
 
         // then
         assertThat(found.getId()).isEqualTo(saved.getId());
-    }
-
-    @Test
-    void 탈퇴한_회원이_다시_가입하면_논리_삭제했던_정보를_물리_삭제하고_새로_저장한다() {
-        // given
-        String providerId = "providerId";
-        String name = "폰트";
-        Member member = memberService.save(providerId, name);
-        LocalDateTime createdAt = LocalDateTime.now();
-        ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
-                "그룹", 10,
-                LocalDate.now(), LocalDate.now().plusDays(3), createdAt
-        ));
-        ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.save(
-                new ChallengeGroupMember(challengeGroup, member));
-
-        memberService.delete(member.getId());
-
-        // when
-        Member found = memberService.save(providerId, name);
-
-        // then
-        assertThat(found.getId()).isNotEqualTo(member.getId());
-        assertThat(challengeGroupMemberRepository.findById(challengeGroupMember.getId()))
-                .isEmpty();
     }
 }

--- a/src/test/java/site/dogether/member/service/MemberServiceTest.java
+++ b/src/test/java/site/dogether/member/service/MemberServiceTest.java
@@ -11,6 +11,7 @@ import site.dogether.challengegroup.repository.ChallengeGroupRepository;
 import site.dogether.member.entity.Member;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,8 +56,10 @@ class MemberServiceTest {
         String providerId = "providerId";
         String name = "폰트";
         Member member = memberService.save(providerId, name);
+        LocalDateTime createdAt = LocalDateTime.now();
         ChallengeGroup challengeGroup = challengeGroupRepository.save(ChallengeGroup.create(
-                "그룹", 10, LocalDate.now(), LocalDate.now().plusDays(3)
+                "그룹", 10,
+                LocalDate.now(), LocalDate.now().plusDays(3), createdAt
         ));
         ChallengeGroupMember challengeGroupMember = challengeGroupMemberRepository.save(
                 new ChallengeGroupMember(challengeGroup, member));


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #216 (이슈 종료가 아니면 `Resolves` 대신 `refs` 키워드를 사용해주세요.)

### 🧑‍💻 수행 작업

주요 변경 사항은 두 가지입니다!

### 1. ChallengeGroup 생성 인터페이스를 한 개의 생성자로 통일

변경 커밋 : 3159992d3ce968cd79aab681c3eaad02016ee399

투두, 사용자 통계 등 여러 도메인에서 ChallengeGroup을 생성해야 하는데, 기존에는 두 가지 생성 방법이 혼재되어 있었습니다.
- 프로덕션: `create()` 정적 팩토리 메서드 (검증 O)
- 테스트: 모든 필드를 받는 생성자 (검증 X, `id`와 `status` 직접 주입)

이로 인한 문제는 다음과 같다고 생각했습니다!
- 앞으로 팀원 분들이 다른 도메인 코드를 추가하면서 어떤 방식으로 ChallengeGroup을 생성해야 할지 명확하지 않다.
- 테스트에서 프로덕션과 다른 방식으로 객체를 만들어 검증 로직을 우회하니, 테스트 신뢰도가 떨어진다.

따라서 단일 생성자만 제공하고, `status`는 `startAt` 날짜를 기반으로 내부에서 계산하도록 변경했습니다.

이제 DailyTodo나 사용자 통계 도메인에서 ChallengeGroup을 생성할 때, 한 가지 명확한 방법만 사용하면 되고, 프로덕션과 테스트 코드가 동일한 방식으로 객체를 생성하여 일관성이 보장됩니다.

### 2. 챌린지 그룹 참가 코드를 원시 타입(String)에서 VO로 리팩토링

변경 커밋: 395300de8a423a875f4d6d8cd145576c7dac511c

- 도메인 로직(생성/검증)을 JoinCode 객체 내부로 캡슐화
- 육안으로 구분이 어려운 문자(0/O/o, 1/I/i/l)를 생성에서 제외하여 코드 입력 시 사용자 혼란을 방지했습니다.

### 📢 참고 사항

리팩토링 크기가 커져서 이쯤에서 PR을 날리고 나머지 리팩토링은 새로운 PR에서 진행해보려고 합니다~~
