### PR TITLE
인증목록 api 내 페이징 처리 로직 수정

### DIFF
--- a/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
+++ b/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
@@ -18,13 +18,13 @@ public interface DailyTodoCertificationRepository extends JpaRepository<DailyTod
 
     Optional<DailyTodoCertification> findByDailyTodo(final DailyTodo dailyTodo);
 
-    List<DailyTodoCertification> findAllByDailyTodo_Member(Member member);
+    List<DailyTodoCertification> findAllByDailyTodo_MemberOrderByCreatedAtDesc(Member member);
 
-    List<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatus(Member member, DailyTodoCertificationReviewStatus reviewStatus);
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(Member member, DailyTodoCertificationReviewStatus reviewStatus);
 
-    Slice<DailyTodoCertification> findAllByDailyTodo_Member(Member member, Pageable pageable);
+    Slice<DailyTodoCertification> findAllByDailyTodo_MemberOrderByCreatedAtDesc(Member member, Pageable pageable);
 
-    Slice<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatus(Member member, DailyTodoCertificationReviewStatus status, Pageable pageable);
+    Slice<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(Member member, DailyTodoCertificationReviewStatus status, Pageable pageable);
 
     @Query("""
     SELECT dtc

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -201,10 +201,10 @@ public class MemberActivityService {
     private List<DailyTodoCertification> getCertificationsByStatus(Member member, String status) {
         if (status != null && !status.isBlank()) {
             final DailyTodoCertificationReviewStatus dailyTodoCertificationReviewStatus = DailyTodoCertificationReviewStatus.convertByValue(status);
-            return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndReviewStatus(member, dailyTodoCertificationReviewStatus);
+            return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(member, dailyTodoCertificationReviewStatus);
         }
 
-        return dailyTodoCertificationRepository.findAllByDailyTodo_Member(member);
+        return dailyTodoCertificationRepository.findAllByDailyTodo_MemberOrderByCreatedAtDesc(member);
     }
 
     private List<GetMemberAllStatsApiResponseV0.CertificationsGroupedByTodoCompletedAt> getCertificationsSortedByTodoCompletedAt(List<DailyTodoCertification> certifications) {

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityServiceV1.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityServiceV1.java
@@ -43,6 +43,7 @@ public class MemberActivityServiceV1 {
         GetMemberAllStatsApiResponseV1.DailyTodoStats stats = getStats(member);
         Slice<DailyTodoCertification> certificationsBySlice = getCertificationsByStatus(member, status, pageable);
         List<DailyTodoCertification> certifications = certificationsBySlice.getContent();
+        GetMemberAllStatsApiResponseV1.from(certificationsBySlice);
 
         if ("TODO_COMPLETED_AT".equals(sort)) {
             List<GetMemberAllStatsApiResponseV1.CertificationsGroupedByTodoCompletedAt> groupedCertifications = getCertificationsSortedByTodoCompletedAt(certifications);
@@ -75,10 +76,10 @@ public class MemberActivityServiceV1 {
     private Slice<DailyTodoCertification> getCertificationsByStatus(Member member, String status, Pageable pageable) {
         if (status != null && !status.isBlank()) {
             final DailyTodoCertificationReviewStatus dailyTodoCertificationReviewStatus = DailyTodoCertificationReviewStatus.convertByValue(status);
-            return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndReviewStatus(member, dailyTodoCertificationReviewStatus, pageable);
+            return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(member, dailyTodoCertificationReviewStatus, pageable);
         }
 
-        return dailyTodoCertificationRepository.findAllByDailyTodo_Member(member, pageable);
+        return dailyTodoCertificationRepository.findAllByDailyTodo_MemberOrderByCreatedAtDesc(member, pageable);
     }
 
     private List<GetMemberAllStatsApiResponseV1.CertificationsGroupedByTodoCompletedAt> getCertificationsSortedByTodoCompletedAt(List<DailyTodoCertification> certifications) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -6,7 +6,7 @@ spring:
     password: root
 
   jpa:
-    hibernate.ddl-auto: create
+    hibernate.ddl-auto: update
 
 logging:
   config: classpath:logback/logback-local.xml


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #233

### 🧑‍💻 수행 작업
기존에는 단순히 페이징 처리 시 DB에 들어있는 데이터 순으로 조회한 다음 페이징을 적용하는 방식이었습니다. 이러한 문제로 인해 더미 데이터를 추가하거나 인증 투두에 문제가 생겼을 때 조회가 이상하게 되는 문제가 발생하여 이를 수정하였습니다.
수정한 결과 DB에 들어있는 데이터들을 우선 인증 날짜를 기준으로 내림차순 정렬을 한 뒤 페이징 처리를 적용하도록 하였습니다.

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Bug Fixes**
  * 인증 데이터 조회 시 최신순(생성 시간 기준 내림차순) 정렬이 일관되게 적용되었습니다.

* **Chores**
  * 로컬 환경 데이터베이스 스키마 초기화 방식을 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->