### PR TITLE
사용자의 인증 목록 전체 조회 API 구현

### DIFF
--- a/src/docs/asciidoc/memberactivity/member-activity-v1.adoc
+++ b/src/docs/asciidoc/memberactivity/member-activity-v1.adoc
@@ -23,7 +23,7 @@ include::{snippets}/member-activity-controller-v1-docs-test/get-group-activity-s
 include::{snippets}/member-activity-controller-v1-docs-test/get-group-activity-stat-v1/http-response.adoc[]
 include::{snippets}/member-activity-controller-v1-docs-test/get-group-activity-stat-v1/response-fields.adoc[]
 
-[[get-member-all-stats-sorted-by-todo-completed-at-v1]]
+[[get-my-activity-stats-and-certifications-sorted-by-certificated-at-v1]]
 === 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 (투두 완료일 순)
 
 ==== 개발 상태
@@ -45,7 +45,7 @@ include::{snippets}/member-activity-controller-v1-docs-test/get-member-all-stats
 include::{snippets}/member-activity-controller-v1-docs-test/get-member-all-stats-sorted-by-todo-completed-at-v1/http-response.adoc[]
 include::{snippets}/member-activity-controller-v1-docs-test/get-member-all-stats-sorted-by-todo-completed-at-v1/response-fields.adoc[]
 
-[[get-member-all-stats-sorted-by-group-created-at-v1]]
+[[get-my-activity-stats-and-certifications-sorted-by-group-created-at-v1]]
 === 사용자의 활동 통계 및 작성한 인증 목록 전체 조회 (그룹 생성일 순)
 
 ==== 개발 상태
@@ -66,6 +66,28 @@ include::{snippets}/member-activity-controller-v1-docs-test/get-member-all-stats
 ==== HTTP Response
 include::{snippets}/member-activity-controller-v1-docs-test/get-member-all-stats-sorted-by-group-created-at-v1/http-response.adoc[]
 include::{snippets}/member-activity-controller-v1-docs-test/get-member-all-stats-sorted-by-group-created-at-v1/response-fields.adoc[]
+
+[[get-my-group-certifications-v1]]
+=== 사용자의 인증 목록 전체 조회 (페이징 X)
+
+==== 개발 상태
+|===
+| 환경 | 구현 여부
+
+| 개발
+| O
+
+| 운영
+| X
+|===
+
+==== HTTP Request
+include::{snippets}/member-activity-controller-v1-docs-test/get-my-group-certifications-v1/http-request.adoc[]
+include::{snippets}/member-activity-controller-v1-docs-test/get-my-group-certifications-v1/query-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/member-activity-controller-v1-docs-test/get-my-group-certifications-v1/http-response.adoc[]
+include::{snippets}/member-activity-controller-v1-docs-test/get-my-group-certifications-v1/response-fields.adoc[]
 
 [[get-my-profile-v1]]
 === 사용자 프로필 조회

--- a/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
+++ b/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
@@ -23,9 +23,14 @@ public interface DailyTodoCertificationRepository extends JpaRepository<DailyTod
 
     Slice<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(final Member member, final DailyTodoCertificationReviewStatus status, final Pageable pageable);
 
-    List<DailyTodoCertification> findAllByDailyTodo_MemberAndCreatedAtOrderByCreatedAtDesc(final Member member, final LocalDateTime certificatedAt);
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndCreatedAtGreaterThanEqualAndCreatedAtLessThanOrderByCreatedAtDesc(final Member member, final LocalDateTime start, final LocalDateTime end);
 
-    List<DailyTodoCertification> findAllByDailyTodo_MemberAndCreatedAtAndReviewStatusOrderByCreatedAtDesc(final Member member, final LocalDateTime certificatedAt, final DailyTodoCertificationReviewStatus reviewStatus);
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndCreatedAtGreaterThanEqualAndCreatedAtLessThanAndReviewStatusOrderByCreatedAtDesc(
+        final Member member,
+        final LocalDateTime start,
+        final LocalDateTime end,
+        final DailyTodoCertificationReviewStatus reviewStatus
+    );
 
     List<DailyTodoCertification> findAllByDailyTodo_MemberAndDailyTodo_ChallengeGroup_NameOrderByCreatedAtDesc(final Member member, final String groupName);
 

--- a/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
+++ b/src/main/java/site/dogether/dailytodocertification/repository/DailyTodoCertificationRepository.java
@@ -11,6 +11,7 @@ import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus;
 import site.dogether.member.entity.Member;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -18,13 +19,17 @@ public interface DailyTodoCertificationRepository extends JpaRepository<DailyTod
 
     Optional<DailyTodoCertification> findByDailyTodo(final DailyTodo dailyTodo);
 
-    List<DailyTodoCertification> findAllByDailyTodo_MemberOrderByCreatedAtDesc(Member member);
+    Slice<DailyTodoCertification> findAllByDailyTodo_MemberOrderByCreatedAtDesc(final Member member, final Pageable pageable);
 
-    List<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(Member member, DailyTodoCertificationReviewStatus reviewStatus);
+    Slice<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(final Member member, final DailyTodoCertificationReviewStatus status, final Pageable pageable);
 
-    Slice<DailyTodoCertification> findAllByDailyTodo_MemberOrderByCreatedAtDesc(Member member, Pageable pageable);
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndCreatedAtOrderByCreatedAtDesc(final Member member, final LocalDateTime certificatedAt);
 
-    Slice<DailyTodoCertification> findAllByDailyTodo_MemberAndReviewStatusOrderByCreatedAtDesc(Member member, DailyTodoCertificationReviewStatus status, Pageable pageable);
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndCreatedAtAndReviewStatusOrderByCreatedAtDesc(final Member member, final LocalDateTime certificatedAt, final DailyTodoCertificationReviewStatus reviewStatus);
+
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndDailyTodo_ChallengeGroup_NameOrderByCreatedAtDesc(final Member member, final String groupName);
+
+    List<DailyTodoCertification> findAllByDailyTodo_MemberAndDailyTodo_ChallengeGroup_NameAndReviewStatusOrderByCreatedAtDesc(final Member member, final String groupName, final DailyTodoCertificationReviewStatus reviewStatus);
 
     @Query("""
     SELECT dtc

--- a/src/main/java/site/dogether/memberactivity/controller/v1/MemberActivityControllerV1.java
+++ b/src/main/java/site/dogether/memberactivity/controller/v1/MemberActivityControllerV1.java
@@ -15,12 +15,14 @@ import site.dogether.common.controller.dto.response.ApiResponse;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.memberactivity.controller.v1.dto.response.GetMyActivityStatsAndCertificationsApiResponseV1;
 import site.dogether.memberactivity.controller.v1.dto.response.GetMyChallengeGroupActivityStatsApiResponseV1;
+import site.dogether.memberactivity.controller.v1.dto.response.GetMyGroupCertificationsApiResponseV1;
 import site.dogether.memberactivity.controller.v1.dto.response.GetMyProfileApiResponseV1;
 import site.dogether.memberactivity.service.MemberActivityService;
 import site.dogether.memberactivity.service.dto.CertificationPeriodDto;
 import site.dogether.memberactivity.service.dto.CertificationsGroupedByCertificatedAtDto;
 import site.dogether.memberactivity.service.dto.CertificationsGroupedByGroupCreatedAtDto;
 import site.dogether.memberactivity.service.dto.ChallengeGroupInfoDto;
+import site.dogether.memberactivity.service.dto.DailyTodoCertificationActivityDto;
 import site.dogether.memberactivity.service.dto.FindMyProfileDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsInChallengeGroupDto;
@@ -85,6 +87,26 @@ public class MemberActivityControllerV1 {
             GetMyActivityStatsAndCertificationsApiResponseV1.CertificationsGroupedByGroupCreatedAt.fromList(groupedCertifications),
             GetMyActivityStatsAndCertificationsApiResponseV1.PageInfo.from(certifications)
         )));
+    }
+
+    @GetMapping("/activity/todos/{todoId}/group-certifications")
+    public ResponseEntity<ApiResponse<GetMyGroupCertificationsApiResponseV1>> getMyGroupCertifications(
+        @Authenticated final Long memberId,
+        @PathVariable final Long todoId,
+        @RequestParam final String sortBy,
+        @RequestParam(required = false) final String status
+    ) {
+        // TODO: 추후 v2 올릴 때 'TODO_COMPLETED_AT'가 아닌 'CERTIFICATED_AT'으로 변경 필요
+        if (sortBy.equals("TODO_COMPLETED_AT")) {
+            final List<DailyTodoCertificationActivityDto> dailyTodoCertificationActivity = memberActivityService.getMyGroupCertificationsByCertificatedAt(memberId, todoId, status);
+
+            return ResponseEntity.ok(success(new GetMyGroupCertificationsApiResponseV1(GetMyGroupCertificationsApiResponseV1.Certification.fromList(dailyTodoCertificationActivity))));
+        }
+
+        // sortBy = GROUP_CREATED_AT
+        final List<DailyTodoCertificationActivityDto> dailyTodoCertificationActivity = memberActivityService.getMyGroupCertificationsByGroupCreatedAt(memberId, todoId, status);
+
+        return ResponseEntity.ok(success(new GetMyGroupCertificationsApiResponseV1(GetMyGroupCertificationsApiResponseV1.Certification.fromList(dailyTodoCertificationActivity))));
     }
 
     @GetMapping("/profile")

--- a/src/main/java/site/dogether/memberactivity/controller/v1/dto/response/GetMyGroupCertificationsApiResponseV1.java
+++ b/src/main/java/site/dogether/memberactivity/controller/v1/dto/response/GetMyGroupCertificationsApiResponseV1.java
@@ -1,0 +1,38 @@
+package site.dogether.memberactivity.controller.v1.dto.response;
+
+import site.dogether.memberactivity.service.dto.DailyTodoCertificationActivityDto;
+
+import java.util.List;
+
+public record GetMyGroupCertificationsApiResponseV1(
+    List<Certification> certifications
+) {
+
+    public record Certification(
+        Long id,
+        String content,
+        String status,
+        boolean canRequestCertificationReview,
+        String certificationContent,
+        String certificationMediaUrl,
+        String reviewFeedback
+    ) {
+        public static List<Certification> fromList(final List<DailyTodoCertificationActivityDto> dtoList) {
+            return dtoList.stream()
+                .map(Certification::from)
+                .toList();
+        }
+
+        public static Certification from(final DailyTodoCertificationActivityDto dto) {
+            return new Certification(
+                dto.id(),
+                dto.content(),
+                dto.status(),
+                dto.canRequestCertificationReview(),
+                dto.certificationContent(),
+                dto.certificationMediaUrl(),
+                dto.reviewFeedback()
+            );
+        }
+    }
+}

--- a/src/main/java/site/dogether/memberactivity/controller/v1/dto/response/GetMyProfileApiResponseV1.java
+++ b/src/main/java/site/dogether/memberactivity/controller/v1/dto/response/GetMyProfileApiResponseV1.java
@@ -6,7 +6,7 @@ public record GetMyProfileApiResponseV1(
         String name,
         String profileImageUrl
 ) {
-    public static GetMyProfileApiResponseV1 from(FindMyProfileDto findMyProfileDto) {
-        return new GetMyProfileApiResponseV1(findMyProfileDto.getName(), findMyProfileDto.getProfileImageUrl());
+    public static GetMyProfileApiResponseV1 from(final FindMyProfileDto dto) {
+        return new GetMyProfileApiResponseV1(dto.name(), dto.profileImageUrl());
     }
 }

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -281,7 +281,7 @@ public class MemberActivityService {
         return certifications.stream()
             .map(certification -> new DailyTodoCertificationActivityDto(
                 certification.getDailyTodo().getId(),
-                certification.getContent(),
+                certification.getDailyTodo().getContent(),
                 certification.getReviewStatus().name(),
                 todoActivityReminderService.canRequestCertificationReview(member, certification),
                 certification.getContent(),
@@ -321,7 +321,7 @@ public class MemberActivityService {
         return certifications.stream()
             .map(certification -> new DailyTodoCertificationActivityDto(
                 certification.getDailyTodo().getId(),
-                certification.getContent(),
+                certification.getDailyTodo().getContent(),
                 certification.getReviewStatus().name(),
                 todoActivityReminderService.canRequestCertificationReview(member, certification),
                 certification.getContent(),

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -13,9 +13,11 @@ import site.dogether.challengegroup.service.ChallengeGroupPolicy;
 import site.dogether.challengegroup.service.ChallengeGroupReader;
 import site.dogether.challengegroup.service.ChallengeGroupService;
 import site.dogether.dailytodo.entity.DailyTodo;
+import site.dogether.dailytodo.exception.DailyTodoNotFoundException;
 import site.dogether.dailytodo.repository.DailyTodoRepository;
 import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus;
+import site.dogether.dailytodocertification.exception.DailyTodoCertificationNotFoundException;
 import site.dogether.dailytodocertification.repository.DailyTodoCertificationCount;
 import site.dogether.dailytodocertification.repository.DailyTodoCertificationRepository;
 import site.dogether.member.entity.Member;
@@ -27,11 +29,13 @@ import site.dogether.memberactivity.service.dto.CertificationPeriodDto;
 import site.dogether.memberactivity.service.dto.CertificationsGroupedByCertificatedAtDto;
 import site.dogether.memberactivity.service.dto.CertificationsGroupedByGroupCreatedAtDto;
 import site.dogether.memberactivity.service.dto.ChallengeGroupInfoDto;
+import site.dogether.memberactivity.service.dto.DailyTodoCertificationActivityDto;
 import site.dogether.memberactivity.service.dto.DailyTodoCertificationInfoDto;
 import site.dogether.memberactivity.service.dto.FindMyProfileDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsInChallengeGroupDto;
 import site.dogether.memberactivity.service.dto.MyRankInChallengeGroupDto;
+import site.dogether.reminder.service.TodoActivityReminderService;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -57,6 +61,7 @@ public class MemberActivityService {
     private final DailyTodoStatsRepository dailyTodoStatsRepository;
     private final MemberRepository memberRepository;
     private final ChallengeGroupService challengeGroupService;
+    private final TodoActivityReminderService todoActivityReminderService;
     private final ChallengeGroupPolicy challengeGroupPolicy;
 
     private static final int CERTIFICATION_PERIOD_DAYS = 4;
@@ -260,6 +265,77 @@ public class MemberActivityService {
                     .collect(Collectors.toList())
             ))
             .collect(Collectors.toList());
+    }
+
+    public List<DailyTodoCertificationActivityDto> getMyGroupCertificationsByCertificatedAt(final Long memberId, final Long todoId, final String status) {
+        final Member member = getMember(memberId);
+        final DailyTodo dailyTodo = getDailyTodo(todoId);
+        final DailyTodoCertification dailyTodoCertification = getDailyTodoCertification(dailyTodo);
+
+        final LocalDateTime date = dailyTodoCertification.getCreatedAt();
+
+        final List<DailyTodoCertification> certifications = getCertificationsByCertificatedAtAndStatus(member, date, status);
+
+        return certifications.stream()
+            .map(certification -> new DailyTodoCertificationActivityDto(
+                certification.getDailyTodo().getId(),
+                certification.getContent(),
+                certification.getReviewStatus().name(),
+                todoActivityReminderService.canRequestCertificationReview(member, certification),
+                certification.getContent(),
+                certification.getMediaUrl(),
+                certification.findReviewFeedback().orElse(null)
+            ))
+            .toList();
+    }
+
+    private DailyTodo getDailyTodo(final Long todoId) {
+        return dailyTodoRepository.findById(todoId)
+            .orElseThrow(() -> new DailyTodoNotFoundException(String.format("존재하지 않는 투두 id입니다. (%d)", todoId)));
+    }
+
+    private DailyTodoCertification getDailyTodoCertification(final DailyTodo dailyTodo) {
+        return dailyTodoCertificationRepository.findByDailyTodo(dailyTodo)
+            .orElseThrow(() -> new DailyTodoCertificationNotFoundException(String.format("존재하지 않는 데일리 투두 인증입니다. 투두 id : (%d)", dailyTodo.getId())));
+    }
+
+    private List<DailyTodoCertification> getCertificationsByCertificatedAtAndStatus(final Member member, final LocalDateTime date, final String status) {
+        if (status != null && !status.isBlank()) {
+            final DailyTodoCertificationReviewStatus dailyTodoCertificationReviewStatus = DailyTodoCertificationReviewStatus.convertByValue(status);
+            return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndCreatedAtAndReviewStatusOrderByCreatedAtDesc(member, date, dailyTodoCertificationReviewStatus);
+        }
+
+        return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndCreatedAtOrderByCreatedAtDesc(member, date);
+    }
+
+    public List<DailyTodoCertificationActivityDto> getMyGroupCertificationsByGroupCreatedAt(final Long memberId, final Long todoId, final String status) {
+        final Member member = getMember(memberId);
+        final DailyTodo dailyTodo = getDailyTodo(todoId);
+
+        final String groupName = dailyTodo.getChallengeGroup().getName();
+
+        final List<DailyTodoCertification> certifications = getCertificationsByGroupNameAndStatus(member, groupName, status);
+
+        return certifications.stream()
+            .map(certification -> new DailyTodoCertificationActivityDto(
+                certification.getDailyTodo().getId(),
+                certification.getContent(),
+                certification.getReviewStatus().name(),
+                todoActivityReminderService.canRequestCertificationReview(member, certification),
+                certification.getContent(),
+                certification.getMediaUrl(),
+                certification.findReviewFeedback().orElse(null)
+            ))
+            .toList();
+    }
+
+    private List<DailyTodoCertification> getCertificationsByGroupNameAndStatus(final Member member, final String groupName, final String status) {
+        if (status != null && !status.isBlank()) {
+            final DailyTodoCertificationReviewStatus dailyTodoCertificationReviewStatus = DailyTodoCertificationReviewStatus.convertByValue(status);
+            return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndDailyTodo_ChallengeGroup_NameAndReviewStatusOrderByCreatedAtDesc(member, groupName, dailyTodoCertificationReviewStatus);
+        }
+
+        return dailyTodoCertificationRepository.findAllByDailyTodo_MemberAndDailyTodo_ChallengeGroup_NameOrderByCreatedAtDesc(member, groupName);
     }
 
     public FindMyProfileDto getMyProfile(final Long memberId) {

--- a/src/main/java/site/dogether/memberactivity/service/dto/DailyTodoCertificationActivityDto.java
+++ b/src/main/java/site/dogether/memberactivity/service/dto/DailyTodoCertificationActivityDto.java
@@ -1,0 +1,12 @@
+package site.dogether.memberactivity.service.dto;
+
+public record DailyTodoCertificationActivityDto(
+    Long id,
+    String content,
+    String status,
+    boolean canRequestCertificationReview,
+    String certificationContent,
+    String certificationMediaUrl,
+    String reviewFeedback
+) {
+}

--- a/src/main/java/site/dogether/memberactivity/service/dto/FindMyProfileDto.java
+++ b/src/main/java/site/dogether/memberactivity/service/dto/FindMyProfileDto.java
@@ -1,17 +1,7 @@
 package site.dogether.memberactivity.service.dto;
 
-import lombok.Getter;
-
-@Getter
-public class FindMyProfileDto {
-    String name;
-    String profileImageUrl;
-
-    public FindMyProfileDto(
-            final String name,
-            final String profileImageUrl
-    ) {
-        this.name = name;
-        this.profileImageUrl = profileImageUrl;
-    }
+public record FindMyProfileDto(
+    String name,
+    String profileImageUrl
+) {
 }

--- a/src/test/java/site/dogether/docs/memberactivity/v1/MemberActivityControllerV1DocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/v1/MemberActivityControllerV1DocsTest.java
@@ -16,6 +16,7 @@ import site.dogether.memberactivity.service.dto.CertificationPeriodDto;
 import site.dogether.memberactivity.service.dto.CertificationsGroupedByCertificatedAtDto;
 import site.dogether.memberactivity.service.dto.CertificationsGroupedByGroupCreatedAtDto;
 import site.dogether.memberactivity.service.dto.ChallengeGroupInfoDto;
+import site.dogether.memberactivity.service.dto.DailyTodoCertificationActivityDto;
 import site.dogether.memberactivity.service.dto.DailyTodoCertificationInfoDto;
 import site.dogether.memberactivity.service.dto.FindMyProfileDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsDto;
@@ -402,6 +403,86 @@ class MemberActivityControllerV1DocsTest extends RestDocsSupport {
                                     .description("현재 페이지 내 인증 목록 개수")
                                     .type(JsonFieldType.NUMBER)
                         )));
+    }
+
+    @DisplayName("[V1] 사용자의 인증 목록 전체 조회 API (페이징 X)")
+    @Test
+    void getMyGroupCertificationsV1() throws Exception {
+        final List<DailyTodoCertificationActivityDto> certifications = List.of(
+            new DailyTodoCertificationActivityDto(
+                1L,
+                "운동 하기",
+                "REJECT",
+                false,
+                "운동 개조짐 ㅋㅋㅋㅋ",
+                "운동 조지는 짤.png",
+                "에이 이건 운동 아니지"
+            ),
+            new DailyTodoCertificationActivityDto(
+                2L,
+                "인강 듣기",
+                "REJECT",
+                false,
+                "인강 진짜 열심히 들었습니다. ㅎ",
+                "인강 달리는 짤.png",
+                "우리 오늘 인강 듣는날 아닌데?"
+            )
+        );
+
+        given(memberActivityService.getMyGroupCertificationsByCertificatedAt(any(), any(), any()))
+            .willReturn(certifications);
+
+        given(memberActivityService.getMyGroupCertificationsByGroupCreatedAt(any(), any(), any()))
+            .willReturn(certifications);
+
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/v1/my/activity/todos/{todoId}/group-certifications", 1)
+                    .param("sortBy", "GROUP_CREATED_AT")
+                    .param("status", "REJECT")
+                    .header("Authorization", "Bearer access_token")
+                    .contentType(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isOk())
+            .andDo(createDocument(
+                queryParameters(
+                    parameterWithName("sortBy")
+                        .description("정렬 방식")
+                        .attributes(constraints("옵션으로 정해진 값만 허용"))
+                        .attributes(options("TODO_COMPLETED_AT(투두 완료일 순)", "GROUP_CREATED_AT(그룹 생성일 순)")),
+                    parameterWithName("status")
+                        .optional()
+                        .description("데일리 투두 상태")
+                        .attributes(constraints("옵션으로 정해진 값만 허용"))
+                        .attributes(options("REVIEW_PENDING(검사 대기)", "APPROVE(인정)", "REJECT(노인정)"))
+                ),
+                responseFields(
+                    fieldWithPath("code")
+                        .description("응답 코드")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("message")
+                        .description("응답 메시지")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.certifications[].id")
+                        .description("데일리 투두 id")
+                        .type(JsonFieldType.NUMBER),
+                    fieldWithPath("data.certifications[].content")
+                        .description("데일리 투두 내용")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.certifications[].status")
+                        .description("데일리 투두 상태")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.certifications[].canRequestCertificationReview")
+                        .description("데일리 투두 인증 검사 요청 가능 여부")
+                        .type(JsonFieldType.BOOLEAN),
+                    fieldWithPath("data.certifications[].certificationContent")
+                        .description("데일리 투두 인증글 내용")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.certifications[].certificationMediaUrl")
+                        .description("데일리 투두 인증글 이미지 URL")
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.certifications[].reviewFeedback")
+                        .description("데일리 투두 인증 검사 피드백")
+                        .type(JsonFieldType.STRING)
+                )));
     }
 
     @DisplayName("[V1] 사용자 프로필 조회 API")


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #244

### 🧑‍💻 수행 작업
- 사용자의 인증 목록 전체 조회 API 명세 문서 추가
- 사용자의 인증 목록 전체 조회 API 구현

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자의 그룹 인증 목록을 반환하는 새 API 엔드포인트 추가(페이징 옵션 포함/비포함 모두 지원).
* **동작 개선**
  * 인증 목록 조회에 대한 페이징 및 정렬 기준 확대(인증 완료일, 그룹 생성일 등).
* **문서**
  * 멤버 활동·인증 관련 문서에 정렬 기준명 및 전체 조회(페이징 X) 항목 추가 및 설명 갱신.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->