### PR TITLE
feat: #251 당일 히스토리 조회 API에 내 히스토리 여부를 확인할 수 있는 isMine 응답 필드 추가

### DIFF
--- a/src/main/java/site/dogether/dailytodo/controller/v2/dto/response/GetChallengeGroupMemberTodayTodoHistoryApiResponseV2.java
+++ b/src/main/java/site/dogether/dailytodo/controller/v2/dto/response/GetChallengeGroupMemberTodayTodoHistoryApiResponseV2.java
@@ -28,7 +28,8 @@ public record GetChallengeGroupMemberTodayTodoHistoryApiResponseV2(
         String certificationMediaUrl,
         boolean isRead,
         @JsonInclude(JsonInclude.Include.NON_NULL)
-        String reviewFeedback
+        String reviewFeedback,
+        boolean isMine
     ) {
         public static TodoData from(final TodoHistoryDto dto) {
             return new TodoData(
@@ -41,7 +42,8 @@ public record GetChallengeGroupMemberTodayTodoHistoryApiResponseV2(
                 dto.certificationContent(),
                 dto.certificationMediaUrl(),
                 dto.isRead(),
-                dto.reviewFeedback()
+                dto.reviewFeedback(),
+                dto.isMine()
             );
         }
     }

--- a/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistory.java
+++ b/src/main/java/site/dogether/dailytodohistory/entity/DailyTodoHistory.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import site.dogether.common.audit.entity.BaseEntity;
 import site.dogether.dailytodo.entity.DailyTodo;
+import site.dogether.member.entity.Member;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -59,5 +60,9 @@ public class DailyTodoHistory extends BaseEntity {
 
     public void updateEventTime() {
         this.eventTime = LocalDateTime.now();
+    }
+
+    public boolean isMine(final Member target) {
+        return dailyTodo.isWriter(target);
     }
 }

--- a/src/main/java/site/dogether/dailytodohistory/service/DailyTodoHistoryService.java
+++ b/src/main/java/site/dogether/dailytodohistory/service/DailyTodoHistoryService.java
@@ -103,7 +103,8 @@ public class DailyTodoHistoryService {
                 dailyTodoCertification.getContent(),
                 dailyTodoCertification.getMediaUrl(),
                 isHistoryRead,
-                dailyTodoCertification.findReviewFeedback().orElse(null)))
+                dailyTodoCertification.findReviewFeedback().orElse(null),
+                history.isMine(viewer)))
             .orElse(new TodoHistoryDto(
                 history.getId(),
                 dailyTodo.getId(),
@@ -114,7 +115,8 @@ public class DailyTodoHistoryService {
                 null,
                 null,
                 isHistoryRead,
-                    null));
+                    null,
+                history.isMine(viewer)));
     }
 
     private boolean checkMemberReadDailyTodoHistory(final Member member, final DailyTodoHistory dailyTodoHistory) {

--- a/src/main/java/site/dogether/dailytodohistory/service/dto/TodoHistoryDto.java
+++ b/src/main/java/site/dogether/dailytodohistory/service/dto/TodoHistoryDto.java
@@ -10,5 +10,6 @@ public record TodoHistoryDto(
     String certificationContent,
     String certificationMediaUrl,
     boolean isRead,
-    String reviewFeedback
+    String reviewFeedback,
+    boolean isMine
 ) {}

--- a/src/test/java/site/dogether/docs/dailytodo/v1/DailyTodoControllerV1DocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/v1/DailyTodoControllerV1DocsTest.java
@@ -25,14 +25,20 @@ import java.util.List;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
-import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_COMPLETED;
 import static site.dogether.dailytodo.entity.DailyTodoStatus.CERTIFY_PENDING;
-import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.*;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.APPROVE;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.REJECT;
+import static site.dogether.dailytodocertification.entity.DailyTodoCertificationReviewStatus.REVIEW_PENDING;
 
 @DisplayName("데일리 투두 V1 API 문서화 테스트")
 public class DailyTodoControllerV1DocsTest extends RestDocsSupport {
@@ -254,12 +260,12 @@ public class DailyTodoControllerV1DocsTest extends RestDocsSupport {
         final FindTargetMemberTodayTodoHistoriesDto serviceMockResponse = new FindTargetMemberTodayTodoHistoriesDto(
             3,
             List.of(
-                new TodoHistoryDto(1L, 1L, "치킨 먹기", CERTIFY_PENDING.name(), true, true, null, null, true, null),
-                new TodoHistoryDto(2L, 2L, "재홍님 갈구기", CERTIFY_PENDING.name(), true, true, null, null, true, null),
-                new TodoHistoryDto(3L, 3L, "치킨 먹기", REVIEW_PENDING.name(), true, true, "개꿀맛 치킨 냠냠", "https://치킨.png", true, null),
-                new TodoHistoryDto(4L, 4L, "재홍님 갈구기", REVIEW_PENDING.name(), true, true, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, null),
-                new TodoHistoryDto(5L, 5L,  "재홍님 갈구기", APPROVE.name(), true, true, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요"),
-                new TodoHistoryDto(6L, 6L,  "치킨 먹기", REJECT.name(), true, true, "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ 심술나서 노인정!")
+                new TodoHistoryDto(1L, 1L, "치킨 먹기", CERTIFY_PENDING.name(), true, true, null, null, true, null, false),
+                new TodoHistoryDto(2L, 2L, "재홍님 갈구기", CERTIFY_PENDING.name(), true, true, null, null, true, null, false),
+                new TodoHistoryDto(3L, 3L, "치킨 먹기", REVIEW_PENDING.name(), true, true, "개꿀맛 치킨 냠냠", "https://치킨.png", true, null, false),
+                new TodoHistoryDto(4L, 4L, "재홍님 갈구기", REVIEW_PENDING.name(), true, true, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, null, false),
+                new TodoHistoryDto(5L, 5L,  "재홍님 갈구기", APPROVE.name(), true, true, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요", false),
+                new TodoHistoryDto(6L, 6L,  "치킨 먹기", REJECT.name(), true, true, "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ 심술나서 노인정!", false)
             )
         );
         given(dailyTodoHistoryService.findAllTodayTodoHistories(any(), any(), any()))

--- a/src/test/java/site/dogether/docs/dailytodo/v2/DailyTodoControllerV2DocsTest.java
+++ b/src/test/java/site/dogether/docs/dailytodo/v2/DailyTodoControllerV2DocsTest.java
@@ -190,12 +190,12 @@ public class DailyTodoControllerV2DocsTest extends RestDocsSupport {
         final FindTargetMemberTodayTodoHistoriesDto serviceMockResponse = new FindTargetMemberTodayTodoHistoriesDto(
             3,
             List.of(
-                new TodoHistoryDto(1L, 1L, "치킨 먹기", CERTIFY_PENDING.name(), true, false, null, null, true, null),
-                new TodoHistoryDto(2L, 2L, "재홍님 갈구기", CERTIFY_PENDING.name(), true, false, null, null, true, null),
-                new TodoHistoryDto(3L, 3L, "치킨 먹기", REVIEW_PENDING.name(), false, true, "개꿀맛 치킨 냠냠", "https://치킨.png", true, null),
-                new TodoHistoryDto(4L, 4L, "재홍님 갈구기", REVIEW_PENDING.name(), false, false, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, null),
-                new TodoHistoryDto(5L, 5L,  "재홍님 갈구기", APPROVE.name(), false, false, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요"),
-                new TodoHistoryDto(6L, 6L,  "치킨 먹기", REJECT.name(), false, false, "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ 심술나서 노인정!")
+                new TodoHistoryDto(1L, 1L, "치킨 먹기", CERTIFY_PENDING.name(), true, false, null, null, true, null, false),
+                new TodoHistoryDto(2L, 2L, "재홍님 갈구기", CERTIFY_PENDING.name(), true, false, null, null, true, null, false),
+                new TodoHistoryDto(3L, 3L, "치킨 먹기", REVIEW_PENDING.name(), false, true, "개꿀맛 치킨 냠냠", "https://치킨.png", true, null, false),
+                new TodoHistoryDto(4L, 4L, "재홍님 갈구기", REVIEW_PENDING.name(), false, false, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, null, false),
+                new TodoHistoryDto(5L, 5L,  "재홍님 갈구기", APPROVE.name(), false, false, "아 재홍님 그거 그렇게 하는거 아닌데", "https://갈굼1.png", false, "재홍님 갈구기 너무 재밌어요", false),
+                new TodoHistoryDto(6L, 6L,  "치킨 먹기", REJECT.name(), false, false, "개꿀맛 치킨 냠냠", "https://치킨.png", false, "치킨 부럽다ㅠㅠ 심술나서 노인정!", false)
             )
         );
         given(dailyTodoHistoryService.findAllTodayTodoHistories(any(), any(), any()))
@@ -259,6 +259,9 @@ public class DailyTodoControllerV2DocsTest extends RestDocsSupport {
                     fieldWithPath("data.todos[].reviewFeedback")
                         .description("데일리 투두 인증 검사 피드백")
                         .optional()
-                        .type(JsonFieldType.STRING))));
+                        .type(JsonFieldType.STRING),
+                    fieldWithPath("data.todos[].isMine")
+                        .description("본인이 작성한 투두의 히스토리인지 여부")
+                        .type(JsonFieldType.BOOLEAN))));
     }
 }


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #251 

### 🧑‍💻 수행 작업
- 당일 히스토리 조회 API에 내 히스토리 여부를 확인할 수 있는 isMine 응답 필드 추가

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신기능**
  * 할일 목록 응답에 현재 사용자가 작성한 할일을 표시하는 지표가 추가되었습니다. 이를 통해 그룹 내 할일 이력을 조회할 때 어느 할일이 본인 것인지 쉽게 구분할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->