### PR TITLE
memberActivity 내부 lazy initialization exception 에러 해결

### DIFF
--- a/src/main/java/site/dogether/memberactivity/controller/v1/MemberActivityControllerV1.java
+++ b/src/main/java/site/dogether/memberactivity/controller/v1/MemberActivityControllerV1.java
@@ -2,7 +2,6 @@ package site.dogether.memberactivity.controller.v1;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,7 +11,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import site.dogether.auth.resolver.Authenticated;
 import site.dogether.common.controller.dto.response.ApiResponse;
-import site.dogether.dailytodocertification.entity.DailyTodoCertification;
 import site.dogether.memberactivity.controller.v1.dto.response.GetMyActivityStatsAndCertificationsApiResponseV1;
 import site.dogether.memberactivity.controller.v1.dto.response.GetMyChallengeGroupActivityStatsApiResponseV1;
 import site.dogether.memberactivity.controller.v1.dto.response.GetMyGroupCertificationsApiResponseV1;
@@ -22,7 +20,7 @@ import site.dogether.memberactivity.service.dto.CertificationPeriodDto;
 import site.dogether.memberactivity.service.dto.ChallengeGroupInfoDto;
 import site.dogether.memberactivity.service.dto.DailyTodoCertificationActivityDto;
 import site.dogether.memberactivity.service.dto.FindMyProfileDto;
-import site.dogether.memberactivity.service.dto.GroupedCertificationsDto;
+import site.dogether.memberactivity.service.dto.MyActivityStatsAndCertificationsDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsDto;
 import site.dogether.memberactivity.service.dto.MyRankInChallengeGroupDto;
 
@@ -61,28 +59,23 @@ public class MemberActivityControllerV1 {
             @RequestParam(required = false) final String status,
             @PageableDefault(size = 50) final Pageable pageable
     ) {
-        final MyCertificationStatsDto myCertificationStats = memberActivityService.getMyTotalCertificationStats(memberId);
-        final Slice<DailyTodoCertification> certifications = memberActivityService.getCertificationsByStatus(memberId, status, pageable);
+        final MyActivityStatsAndCertificationsDto myActivityStatsAndCertifications = memberActivityService.getMyActivityStatsAndCertifications(memberId, sortBy, status, pageable);
 
         if (sortBy.equals("TODO_COMPLETED_AT")) {
-            final List<GroupedCertificationsDto> groupedCertifications = memberActivityService.certificationsGroupedByCertificatedAt(certifications.getContent());
-
             return ResponseEntity.ok(success(new GetMyActivityStatsAndCertificationsApiResponseV1(
-                GetMyActivityStatsAndCertificationsApiResponseV1.MyCertificationStats.from(myCertificationStats),
-                GetMyActivityStatsAndCertificationsApiResponseV1.CertificationsGroupedByCertificatedAt.fromList(groupedCertifications),
+                GetMyActivityStatsAndCertificationsApiResponseV1.MyCertificationStats.from(myActivityStatsAndCertifications.myCertificationStats()),
+                GetMyActivityStatsAndCertificationsApiResponseV1.CertificationsGroupedByCertificatedAt.fromList(myActivityStatsAndCertifications.groupedCertifications()),
                 null,
-                GetMyActivityStatsAndCertificationsApiResponseV1.PageInfo.from(certifications)
+                GetMyActivityStatsAndCertificationsApiResponseV1.PageInfo.from(myActivityStatsAndCertifications.certifications())
             )));
         }
 
         // sortBy = GROUP_CREATED_AT
-        final List<GroupedCertificationsDto> groupedCertifications = memberActivityService.certificationsGroupedByGroupCreatedAt(certifications.getContent());
-
         return ResponseEntity.ok(success(new GetMyActivityStatsAndCertificationsApiResponseV1(
-            GetMyActivityStatsAndCertificationsApiResponseV1.MyCertificationStats.from(myCertificationStats),
+            GetMyActivityStatsAndCertificationsApiResponseV1.MyCertificationStats.from(myActivityStatsAndCertifications.myCertificationStats()),
             null,
-            GetMyActivityStatsAndCertificationsApiResponseV1.CertificationsGroupedByGroupCreatedAt.fromList(groupedCertifications),
-            GetMyActivityStatsAndCertificationsApiResponseV1.PageInfo.from(certifications)
+            GetMyActivityStatsAndCertificationsApiResponseV1.CertificationsGroupedByGroupCreatedAt.fromList(myActivityStatsAndCertifications.groupedCertifications()),
+            GetMyActivityStatsAndCertificationsApiResponseV1.PageInfo.from(myActivityStatsAndCertifications.certifications())
         )));
     }
 

--- a/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
+++ b/src/main/java/site/dogether/memberactivity/service/MemberActivityService.java
@@ -33,6 +33,7 @@ import site.dogether.memberactivity.service.dto.DailyTodoCertificationInfoDto;
 import site.dogether.memberactivity.service.dto.FindMyProfileDto;
 import site.dogether.memberactivity.service.dto.GroupedCertificationsDto;
 import site.dogether.memberactivity.service.dto.GroupedCertificationsResultDto;
+import site.dogether.memberactivity.service.dto.MyActivityStatsAndCertificationsDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsDto;
 import site.dogether.memberactivity.service.dto.MyRankInChallengeGroupDto;
 import site.dogether.reminder.service.TodoActivityReminderService;
@@ -201,7 +202,29 @@ public class MemberActivityService {
         );
     }
 
-    public MyCertificationStatsDto getMyTotalCertificationStats(final Long memberId) {
+    public MyActivityStatsAndCertificationsDto getMyActivityStatsAndCertifications(
+        final Long memberId,
+        final String sortBy,
+        final String status,
+        final Pageable pageable
+    ) {
+        final MyCertificationStatsDto myCertificationStats = getMyTotalCertificationStats(memberId);
+        final Slice<DailyTodoCertification> certifications = getCertificationsByStatus(memberId, status, pageable);
+
+        List<GroupedCertificationsDto> groupedCertifications = new ArrayList<>();
+
+        if (sortBy.equals("TODO_COMPLETED_AT")) {
+            groupedCertifications = certificationsGroupedByCertificatedAt(certifications.getContent());
+        }
+
+        if (sortBy.equals("GROUP_CREATED_AT")) {
+            groupedCertifications = certificationsGroupedByGroupCreatedAt(certifications.getContent());
+        }
+
+        return new MyActivityStatsAndCertificationsDto(myCertificationStats, certifications, groupedCertifications);
+    }
+
+    private MyCertificationStatsDto getMyTotalCertificationStats(final Long memberId) {
         final Member member = getMember(memberId);
 
         return dailyTodoStatsRepository.findByMember(member)
@@ -213,7 +236,7 @@ public class MemberActivityService {
             .orElseGet(() -> new MyCertificationStatsDto(0, 0, 0));
     }
 
-    public Slice<DailyTodoCertification> getCertificationsByStatus(final Long memberId, final String status, final Pageable pageable) {
+    private Slice<DailyTodoCertification> getCertificationsByStatus(final Long memberId, final String status, final Pageable pageable) {
         final Member member = getMember(memberId);
 
         if (status != null && !status.isBlank()) {
@@ -224,7 +247,7 @@ public class MemberActivityService {
         return dailyTodoCertificationRepository.findAllByDailyTodo_MemberOrderByCreatedAtDesc(member, pageable);
     }
 
-    public List<GroupedCertificationsDto> certificationsGroupedByCertificatedAt(final List<DailyTodoCertification> certifications) {
+    private List<GroupedCertificationsDto> certificationsGroupedByCertificatedAt(final List<DailyTodoCertification> certifications) {
         return certifications.stream()
             .collect(Collectors.groupingBy(certification -> certification.getCreatedAt().toLocalDate().format(DATE_FORMATTER)))
             .entrySet().stream()
@@ -252,7 +275,7 @@ public class MemberActivityService {
         );
     }
 
-    public List<GroupedCertificationsDto> certificationsGroupedByGroupCreatedAt(final List<DailyTodoCertification> certifications) {
+    private List<GroupedCertificationsDto> certificationsGroupedByGroupCreatedAt(final List<DailyTodoCertification> certifications) {
         return certifications.stream()
             .collect(Collectors.groupingBy(certification -> certification.getDailyTodo().getChallengeGroup()))
             .entrySet().stream()

--- a/src/main/java/site/dogether/memberactivity/service/dto/MyActivityStatsAndCertificationsDto.java
+++ b/src/main/java/site/dogether/memberactivity/service/dto/MyActivityStatsAndCertificationsDto.java
@@ -1,0 +1,13 @@
+package site.dogether.memberactivity.service.dto;
+
+import org.springframework.data.domain.Slice;
+import site.dogether.dailytodocertification.entity.DailyTodoCertification;
+
+import java.util.List;
+
+public record MyActivityStatsAndCertificationsDto(
+    MyCertificationStatsDto myCertificationStats,
+    Slice<DailyTodoCertification> certifications,
+    List<GroupedCertificationsDto> groupedCertifications
+) {
+}

--- a/src/test/java/site/dogether/docs/memberactivity/v1/MemberActivityControllerV1DocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/v1/MemberActivityControllerV1DocsTest.java
@@ -18,6 +18,7 @@ import site.dogether.memberactivity.service.dto.DailyTodoCertificationActivityDt
 import site.dogether.memberactivity.service.dto.DailyTodoCertificationInfoDto;
 import site.dogether.memberactivity.service.dto.FindMyProfileDto;
 import site.dogether.memberactivity.service.dto.GroupedCertificationsDto;
+import site.dogether.memberactivity.service.dto.MyActivityStatsAndCertificationsDto;
 import site.dogether.memberactivity.service.dto.MyCertificationStatsDto;
 import site.dogether.memberactivity.service.dto.MyRankInChallengeGroupDto;
 
@@ -152,7 +153,7 @@ class MemberActivityControllerV1DocsTest extends RestDocsSupport {
 
         final Slice<DailyTodoCertification> slice = new SliceImpl<>(List.of(), PageRequest.of(0, 50), false);
 
-        final List<GroupedCertificationsDto> certificationsGroupedByCertificatedAt = List.of(
+        final List<GroupedCertificationsDto> certifications = List.of(
                 new GroupedCertificationsDto(
                         "2025.05.01",
                         List.of(
@@ -181,14 +182,10 @@ class MemberActivityControllerV1DocsTest extends RestDocsSupport {
                 )
         );
 
-        given(memberActivityService.getMyTotalCertificationStats(any()))
-                .willReturn(stats);
+        final MyActivityStatsAndCertificationsDto dto = new MyActivityStatsAndCertificationsDto(stats, slice, certifications);
 
-        given(memberActivityService.getCertificationsByStatus(any(), any(), any()))
-            .willReturn(slice);
-
-        given(memberActivityService.certificationsGroupedByCertificatedAt(any()))
-            .willReturn(certificationsGroupedByCertificatedAt);
+        given(memberActivityService.getMyActivityStatsAndCertifications(any(), any(), any(), any()))
+                .willReturn(dto);
 
         mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/v1/my/activity")
@@ -283,7 +280,7 @@ class MemberActivityControllerV1DocsTest extends RestDocsSupport {
 
         final Slice<DailyTodoCertification> slice = new SliceImpl<>(List.of(), PageRequest.of(0, 50), false);
 
-        final List<GroupedCertificationsDto> certificationsGroupedByGroupCreatedAt = List.of(
+        final List<GroupedCertificationsDto> certifications = List.of(
                 new GroupedCertificationsDto(
                         "스쿼트 챌린지",
                         List.of(
@@ -312,14 +309,10 @@ class MemberActivityControllerV1DocsTest extends RestDocsSupport {
                 )
         );
 
-        given(memberActivityService.getMyTotalCertificationStats(any()))
-            .willReturn(stats);
+        final MyActivityStatsAndCertificationsDto dto = new MyActivityStatsAndCertificationsDto(stats, slice, certifications);
 
-        given(memberActivityService.getCertificationsByStatus(any(), any(), any()))
-            .willReturn(slice);
-
-        given(memberActivityService.certificationsGroupedByGroupCreatedAt(any()))
-            .willReturn(certificationsGroupedByGroupCreatedAt);
+        given(memberActivityService.getMyActivityStatsAndCertifications(any(), any(), any(), any()))
+            .willReturn(dto);
 
         mockMvc.perform(
                         MockMvcRequestBuilders.get("/api/v1/my/activity")

--- a/src/test/java/site/dogether/docs/memberactivity/v2/MemberActivityControllerV2DocsTest.java
+++ b/src/test/java/site/dogether/docs/memberactivity/v2/MemberActivityControllerV2DocsTest.java
@@ -168,7 +168,7 @@ class MemberActivityControllerV2DocsTest extends RestDocsSupport {
 
         mockMvc.perform(
                 MockMvcRequestBuilders.get("/api/v2/my/certifications")
-                    .param("sortBy", "TODO_COMPLETED_AT")
+                    .param("sortBy", "CERTIFICATED_AT")
                     .param("status", "APPROVE")
                     .param("page", "0")
                     .header("Authorization", "Bearer access_token")


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #253

### 🧑‍💻 수행 작업
- memberActivity 내 '사용자의 활동 통계 및 작성한 인증 목록 전체 조회' V1 api가 LazyInitializationException이 터지는 문제 해결
- V2 사용자 인증 목록 전체 조회 API 명세 문서 내 request url 내부 값 변경

### 📢 참고 사항
V2 문서 변경은 값만 하나 바꿔주면 되는 간단한 작업이여서 해당 PR에서 같이 처리하였습니다..!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 주요 변경 사항

* **리팩토링**
  * 회원 활동 통계 및 인증 조회 기능을 통합하여 API 응답 구조를 개선했습니다.
  * 인증 데이터를 완료 날짜 또는 그룹 생성 날짜로 정렬하는 옵션을 추가했습니다.

* **테스트**
  * API 테스트를 리팩토링된 구조에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->