### PR TITLE
todo_activity_reminder_history 연관 테이블 cascade 추가

### DIFF
--- a/src/main/java/site/dogether/member/entity/Member.java
+++ b/src/main/java/site/dogether/member/entity/Member.java
@@ -22,6 +22,7 @@ import site.dogether.dailytodohistory.entity.DailyTodoHistoryRead;
 import site.dogether.member.exception.InvalidMemberException;
 import site.dogether.memberactivity.entity.DailyTodoStats;
 import site.dogether.notification.entity.NotificationToken;
+import site.dogether.reminder.entity.TodoActivityReminderHistory;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -68,6 +69,10 @@ public class Member extends BaseEntity {
     @ToString.Exclude
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     private List<DailyTodoHistoryRead> dailyTodoHistoryRead;
+
+    @ToString.Exclude
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+    private List<TodoActivityReminderHistory> todoActivityReminderHistories;
 
     @ToString.Exclude
     @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)


### PR DESCRIPTION
### 😉 연관 이슈
Resolves #261

### 🧑‍💻 수행 작업
- todo_activity_reminder_history 테이블의 cascade를 member entity 내부에 추가하였음

### 📢 참고 사항
X


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * Member 엔티티에 알림 활동 이력 추적 관계가 추가되었습니다. 이제 시스템은 회원별 알림 이력을 데이터베이스에서 관리할 수 있으며, 회원 삭제 시 관련 알림 이력이 함께 삭제됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->